### PR TITLE
Add <any> type to RemoteStream and RemoteDataTable

### DIFF
--- a/static/base/DefaultEntities.d.ts
+++ b/static/base/DefaultEntities.d.ts
@@ -14322,7 +14322,7 @@ declare interface ThingTemplates {
 	/**
 	 * Remote Data Table
 	 */
-	RemoteDataTable: ThingTemplateEntity<RemoteDataTable>;
+	RemoteDataTable: ThingTemplateEntity<RemoteDataTable<any>>;
 
 	/**
 	 * 
@@ -14467,7 +14467,7 @@ declare interface ThingTemplates {
 	/**
 	 * Remote Stream
 	 */
-	RemoteStream: ThingTemplateEntity<RemoteStream>;
+	RemoteStream: ThingTemplateEntity<RemoteStream<any>>;
 
 	/**
 	 * Template for a Thing that sends notifications when an event occurs


### PR DESCRIPTION
I had to add this code, otherwise I'd get an error when trying to build the entities.

![image](https://user-images.githubusercontent.com/53790047/114112915-4417f500-9892-11eb-86d6-ff7274675ab7.png)
