### PR TITLE
Use ES6 variable declaration and Typescript type consistently in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There are many advantages to this, and here are some of them:
 
 The following software is required:
 
-* [NodeJS](https://nodejs.org/en/): needs to be installed and added to the `PATH`. You should use the LTS version.
+* [NodeJS](https://nodejs.org/en/): needs to be installed and added to the `PATH`. You should use the LTS version (v14+).
 * [gulp command line utility](https://gulpjs.com/docs/en/getting-started/quick-start): is needed to run the build script.
 
 The following software is recommended:
@@ -59,7 +59,7 @@ ThingworxVSCodeProject
 │   metadata.xml      // thingworx metadata file for this widget. This is automatically updated based on your package.json and build settings
 │   LICENSE           // license file
 │   gulpfile.js       // build script
-└───src               // main folder where your developement will take place
+└───src               // main folder where your development will take place
 │   │   file1.ts            // thingworx entity file
 |   |   ...
 └───static            // supporting files required for compilation. Don't change these.
@@ -78,7 +78,7 @@ Any TypeScript file you add to the `src` folder will be compiled into a Thingwor
     - Interface definitions
     - Enums, but only if they are declared `const` since these are erased at runtime
     - Comments
- - Property, method argument and return types must only be Thingworx base types. You can only use TypeScript standard types such as `string`, `number` and others in method bodies
+ - Property, method argument and return types can use either Thingworx base types or TypeScript standard types such as `string`, `number`. 
  - Imports and modules are ignored; these will lead to runtime errors if used
 
 

--- a/src/ConfigurationTableShapes/PortInfo.ts
+++ b/src/ConfigurationTableShapes/PortInfo.ts
@@ -1,9 +1,9 @@
 class PortInfo extends DataShapeBase {
 
-    server: STRING = 'localhost';
+    server: string = 'localhost';
 
-    port: NUMBER = 80;
+    port: number = 80;
 
-    useSSL: BOOLEAN = false;
+    useSSL: boolean = false;
 
 }

--- a/src/MyDataShape.ts
+++ b/src/MyDataShape.ts
@@ -7,7 +7,7 @@ class LinkedList extends DataShapeBase {
      * Data shape fields are specified as properties. The `@primaryKey` decorator
      * can be used to mark fields as primary keys.
      */
-    @primaryKey name!: STRING;
+    @primaryKey name!: string;
 
     /**
      * The `@ordinal` decorator can be used to specify ordinal values for data shape fields.

--- a/src/MyShape.ts
+++ b/src/MyShape.ts
@@ -17,19 +17,19 @@ interface StatusReponse {
  */
 class ExampleThingShape extends ThingShapeBase {
 
-    @logged @persistent pressure: NUMBER = 10;
+    @logged @persistent pressure: number = 10;
 
-    @remote('humidity') humidity!: NUMBER;
+    @remote('humidity') humidity!: number;
 
-    GetPressure(): NUMBER {
+    GetPressure(): number {
         return this.pressure;
     }
 
-    SetPressure({pressure}: {pressure: NUMBER}): NOTHING {
+    SetPressure({pressure}: {pressure: number}): void {
         this.pressure = pressure;
     }
 
-    @remoteService('SetHumidity') SetHumidity({humidity}: {humidity: NUMBER}): NOTHING {}
+    @remoteService('SetHumidity') SetHumidity({humidity}: {humidity: number}): void {}
 
     /**
      * There are no interface types in Thingworx, but in a similar manner to string and number types,
@@ -40,7 +40,7 @@ class ExampleThingShape extends ThingShapeBase {
      * @param factor    A factor by which to multiply the values.
      * @return          An object containing the requested values.
      */
-    GetValuesWithFactor({factor = 1}: {factor?: NUMBER}): TWJSON<StatusReponse> {
+    GetValuesWithFactor({factor = 1}: {factor?: number}): TWJSON<StatusReponse> {
         return {
             pressure: factor * this.pressure,
             humidity: factor * this.humidity

--- a/src/MyThing.ts
+++ b/src/MyThing.ts
@@ -36,8 +36,8 @@ const enum Status {
 
     /**
      * Thing properties are specified as regular class properties.
-     * Note that a type annotation is required and must be one of the Thingworx
-     * base types (e.g. `STRING` instead of `string`).
+     * Note that a type annotation is required and can be one of the standard
+     * Typescript types or Thingworx base types (e.g. `STRING` instead of `string`).
      * 
      * Aspects such as `persistent` and `logged` are specified as decorators.
      * The `readonly` aspect is specified via the regular `readonly` keyword.
@@ -52,12 +52,14 @@ const enum Status {
     @persistent numberProperty!: number;
 
     /**
-     * We can constrain strings to enum values on the compiler side.
+     * We can constrain strings to enum values on the compiler side. The ThingWorx type
+     * (ie. `STRING` not `string`) must be used when constraining properties like this.
      */
     cardType: STRING<Cards> = Cards.Clubs;
 
     /**
-     * Number types can be constrained in the same way as strings.
+     * Number types can be constrained in the same way as strings. The ThingWorx type
+     * (ie. `NUMBER` not `number`) must be used when constraining properties like this.
      */
     status: NUMBER<Status> = Status.Error;
 
@@ -68,7 +70,7 @@ const enum Status {
      *  - The first parameter is the name of the source thing.
      *  - The second parameter is the name of the property to bind to.
      */
-    @local('AuditArchiveCleanupScheduler', 'Enabled') readonly locallyBoundProperty!: STRING;
+    @local('AuditArchiveCleanupScheduler', 'Enabled') readonly locallyBoundProperty!: string;
 
     /**
      * Remotely bound properties are specified via the 
@@ -76,7 +78,7 @@ const enum Status {
      * the first parameter is required. It represents the name of the remote property.
      */
     @remote('test', {cacheTime: 0, foldType: 'NONE', pushType: "Value"}) 
-    remotelyBoundProperty!: NUMBER;
+    remotelyBoundProperty!: number;
 
     /**
      * The data change type is specified via the `@dataChangeType(type)` decorator.
@@ -101,10 +103,10 @@ const enum Status {
      * 
      * Service parameters must be specified as a destructured object like in the example below.
      */
-    @final async asyncService({stringParameter = "Parameter default value", infoTable}: {stringParameter: STRING, infoTable?: INFOTABLE<GenericStringList>}) {
+    @final async asyncService({stringParameter = "Parameter default value", infoTable}: {stringParameter: string, infoTable?: INFOTABLE<GenericStringList>}) {
         // `this` should be used in place of `me`, unlike in thingworx
         // it will be compiled into `me`
-        var x = Things[this.streamToUse];
+        const x = Things[this.streamToUse];
 
         // Constrained strings will cause a compiler error whenever anything other than
         // an enum constant is assigned to it
@@ -115,9 +117,9 @@ const enum Status {
 
         this.streamToUse = 'AnomalyMonitorStateStream';
 
-        var data = x.QueryStreamEntriesWithData();
+        const data = x.QueryStreamEntriesWithData();
 
-        var y = Things.DownloadedSolutions;
+        const y = Things.DownloadedSolutions;
         y.AnyAlertAck();
 
         this.customEvent({item: 'test'});
@@ -128,7 +130,7 @@ const enum Status {
      * Remote services are specified via `@remoteService` decorator. Just like with properties, only the first parameter
      * of this decorator is required.
      */
-    @remoteService('remoteService', {enableQueue: true}) remoteService(): NOTHING {}
+    @remoteService('remoteService', {enableQueue: true}) remoteService(): void {}
 
     /**
      * The `@localSubscription(event[, property])` decorator is used to create subscription to an entity's own events.
@@ -147,7 +149,7 @@ const enum Status {
      * 
      * Note that in this case, the name of the parameters used by this method cannot be changed or it will lead to runtime errors.
      */
-    @subscription('AuditDataTable', 'DataChange', "thingTemplate") auditDataTableThingTemplateChanged(alertName: STRING, eventData: INFOTABLE<DataChangeEvent>, eventName: STRING, eventTime: DATETIME, source: STRING, sourceProperty: STRING) {
+    @subscription('AuditDataTable', 'DataChange', "thingTemplate") auditDataTableThingTemplateChanged(alertName: string, eventData: INFOTABLE<DataChangeEvent>, eventName: string, eventTime: Date, source: string, sourceProperty: string) {
         // Const enums will be fully erased in thingworx
         // This condition will be compiled as this.status == 0
         if (this.status == Status.Running) {


### PR DESCRIPTION
Just some went through the examples and readme. I specified that you need Node v14, not just any LTS version. We were using LTS: Erbium (12.22) and were getting errors about the nullish coalescing operator (`??`). Using Node v14+ fixed this problem.