### PR TITLE
Configuration support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "bm-thingworx-vscode",
 	"packageName": "bm-thingworx-vscode",
 	"moduleName": "bm-thingworx-vscode",
-	"version": "1.4.0-beta.1",
+	"version": "1.5.0-beta.1",
 	"description": "Develop in ThingWorx with a proper IDE.",
 	"author": "Thingworx RoIcenter",
 	"thingworxProjectName": "MyProject",
@@ -33,7 +33,7 @@
 	"devDependencies": {
 		"@types/node": "^8.10.11",
 		"babel-plugin-remove-import-export": "^1.1.0",
-		"bm-thing-transformer": "^0.13.0-beta.1",
+		"bm-thing-transformer": "^0.14.0-beta.1",
 		"cli-progress": "^3.6.1",
 		"del": "^5.0.0",
 		"delete-empty": "^3.0.0",

--- a/static/base/Decorators.d.ts
+++ b/static/base/Decorators.d.ts
@@ -170,6 +170,12 @@ declare function override<T extends GenericThing>(target: T, key: string, descri
  */
 declare function deploy<T extends GenericThing>(target: T, key: string, descriptor: TypedPropertyDescriptor<(...args: any[]) => any>): void;
 
+/**
+ * When applied to an entity, this causes a configuration table to be emitted for it.
+ * @param config        A map of configuration tables.
+ */
+declare function config(config: Record<string, any>): (target: new (...args) => any) => void;
+
 declare interface _remoteServiceArgsLiteral {
     /**
      * Enables queueing for this remote service.

--- a/static/base/TWBaseTypes.d.ts
+++ b/static/base/TWBaseTypes.d.ts
@@ -393,6 +393,11 @@ type Statics<T> = {
     [P in keyof T]: T[P];
 }
 
+declare function DataThing<D extends DataShapeBase>(type: Constructor<Stream<DataShapeBase>>, shape: Constructor<D>): Constructor<Stream<D>>;
+declare function DataThing<D extends DataShapeBase>(type: Constructor<RemoteStream<DataShapeBase>>, shape: Constructor<D>): Constructor<RemoteStream<D>>;
+declare function DataThing<D extends DataShapeBase>(type: Constructor<DataTable<DataShapeBase>>, shape: Constructor<D>): Constructor<DataTable<D>>;
+declare function DataThing<D extends DataShapeBase>(type: Constructor<RemoteDataTable<DataShapeBase>>, shape: Constructor<D>): Constructor<RemoteDataTable<D>>;
+
 /**
  * Allows referencing thing templates with non-standard names in extends clauses.
  * @param name  The name of the ThingTemplate
@@ -434,7 +439,7 @@ declare function ThingTemplateWithShapes<
     (T8 extends Constructor<ThingShapeBase> ? Statics<T8> : {}) &
     (T9 extends Constructor<ThingShapeBase> ? Statics<T9> : {}) &
     (T10 extends Constructor<ThingShapeBase> ? Statics<T10> : {}) &
-    (new (...args: T1 extends Constructor<GenericThing> ? ConstructorParameters<T1> : never[]) =>
+    (new (...args: T1 extends Constructor<GenericThing> ? ConstructorParameters<T1> : never[]) => (
         (T1 extends Constructor<GenericThing> ? InstanceType<T1> : T1) &
         (T2 extends Constructor<ThingShapeBase> ? InstanceType<T2> : T2) &
         (T3 extends Constructor<ThingShapeBase> ? InstanceType<T3> : T3) &
@@ -445,7 +450,7 @@ declare function ThingTemplateWithShapes<
         (T8 extends Constructor<ThingShapeBase> ? InstanceType<T8> : T8) &
         (T9 extends Constructor<ThingShapeBase> ? InstanceType<T9> : T9) &
         (T10 extends Constructor<ThingShapeBase> ? InstanceType<T10> : T10)
-    );
+    ));
 
 type ThingTemplateInstance<T extends keyof ThingTemplates> = ThingTemplates[T]["__thingTemplateType"];
 type ThingShapeInstance<T extends keyof ThingShapes> = ThingShapes[T]["__thingShapeType"];


### PR DESCRIPTION
Adds a new `@config` decorator that can be used to specify configuration table values. Note that this isn't properly type checked yet.

Adds a new `DataThing` utility function declaration that can be used to obtain a data thing constructor with the appropriate generic argument when using `ThingTemplateWithShapes`.