### PR TITLE
Unit decorator support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 13 Oct 2021
+
+Added support for the `@unit` decorator which can be used to specify a unit for numeric properties.
+
 # 28 Jun 2021
 
 Added support for the `@allow`, `@allowInstance`, `@deny` and `@denyInstance` decorators which can be used to specify permissions at the entity or property, service or event levels.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "bm-thingworx-vscode",
-	"version": "1.5.0-beta.1",
+	"version": "1.6.0-beta.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "bm-thingworx-vscode",
-			"version": "1.5.0-beta.1",
+			"version": "1.6.0-beta.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^8.10.11",
 				"babel-plugin-remove-import-export": "^1.1.0",
-				"bm-thing-transformer": "^0.15.0-beta.1",
+				"bm-thing-transformer": "^0.16.0-beta.1",
 				"cli-progress": "^3.6.1",
 				"del": "^5.0.0",
 				"delete-empty": "^3.0.0",
@@ -650,9 +650,9 @@
 			}
 		},
 		"node_modules/bm-thing-transformer": {
-			"version": "0.15.0-beta.1",
-			"resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-0.15.0-beta.1.tgz",
-			"integrity": "sha512-Z3ehNollF2FYfevBLxBupmBZRPx2sP4VNZSlQhuhQfK11Ns6fDvZMG6g3JpsVlglNjDU6isGxcP0F3yDwAdDmg==",
+			"version": "0.16.0-beta.1",
+			"resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-0.16.0-beta.1.tgz",
+			"integrity": "sha512-wxOsdpfIEuv8D2Dm10dyWKVIuRW7+BbOIlFB8h5nahJmPepBixeRx30oF5Ufx/P4AZ1YahH+6ZcbUyufVI8E3w==",
 			"dev": true
 		},
 		"node_modules/brace-expansion": {
@@ -1018,9 +1018,9 @@
 			}
 		},
 		"node_modules/cli-progress/node_modules/ansi-regex": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=8"
@@ -6146,9 +6146,9 @@
 			}
 		},
 		"bm-thing-transformer": {
-			"version": "0.15.0-beta.1",
-			"resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-0.15.0-beta.1.tgz",
-			"integrity": "sha512-Z3ehNollF2FYfevBLxBupmBZRPx2sP4VNZSlQhuhQfK11Ns6fDvZMG6g3JpsVlglNjDU6isGxcP0F3yDwAdDmg==",
+			"version": "0.16.0-beta.1",
+			"resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-0.16.0-beta.1.tgz",
+			"integrity": "sha512-wxOsdpfIEuv8D2Dm10dyWKVIuRW7+BbOIlFB8h5nahJmPepBixeRx30oF5Ufx/P4AZ1YahH+6ZcbUyufVI8E3w==",
 			"dev": true
 		},
 		"brace-expansion": {
@@ -6446,9 +6446,9 @@
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 					"dev": true
 				},
 				"is-fullwidth-code-point": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "bm-thingworx-vscode",
 	"packageName": "bm-thingworx-vscode",
 	"moduleName": "bm-thingworx-vscode",
-	"version": "1.5.0-beta.1",
+	"version": "1.6.0-beta.1",
 	"description": "Develop in ThingWorx with a proper IDE.",
 	"author": "Thingworx RoIcenter",
 	"thingworxProjectName": "MyProject",
@@ -33,7 +33,7 @@
 	"devDependencies": {
 		"@types/node": "^8.10.11",
 		"babel-plugin-remove-import-export": "^1.1.0",
-		"bm-thing-transformer": "^0.15.0-beta.1",
+		"bm-thing-transformer": "^0.16.0-beta.1",
 		"cli-progress": "^3.6.1",
 		"del": "^5.0.0",
 		"delete-empty": "^3.0.0",

--- a/src/MyThing.ts
+++ b/src/MyThing.ts
@@ -73,6 +73,11 @@ const enum Status {
     @local('AuditArchiveCleanupScheduler', 'Enabled') readonly locallyBoundProperty!: string;
 
     /**
+     * Numeric properties can use some specific decorators such as `minimumValue`, `maximumValue` and `unit`.
+     */
+    @minimumValue(32) @maximumValue(64) @unit('bytes') bytes!: number;
+
+    /**
      * Remotely bound properties are specified via the 
      * `@remote(name, {cacheTime?, pushType?, pushThreshold?, startType?,foldType?, imeout?})` decorator. From this decorator only
      * the first parameter is required. It represents the name of the remote property.

--- a/static/base/Decorators.d.ts
+++ b/static/base/Decorators.d.ts
@@ -77,15 +77,23 @@ declare function persistent<T extends GenericThing, P>(target: T, key: string, d
 declare function logged<T extends GenericThing, P>(target: T, key: string, descriptor?: TypedPropertyDescriptor<P extends Function ? never : P>): void;
 
 /**
- * When applied to a property or data shape field, this sets the property's minimum value aspect.
+ * When applied to a numeric property or data shape field, this sets the property's minimum value aspect.
+ * @param minimumValue      The minimum value to set. This must be a numeric literal.
  */
- declare function minimumValue(minimumValue: number): <T extends GenericThing | DataShapeBase, P>(target: T, key: string, descriptor?: TypedPropertyDescriptor<P extends Function ? never : P>) => void;
+declare function minimumValue(minimumValue: number): <T extends GenericThing | DataShapeBase, P extends number>(target: T, key: string, descriptor?: TypedPropertyDescriptor<P>) => void;
 
- /**
-  * When applied to a property or data shape field, this sets the property's maximum value aspect.
-  */
- declare function maximumValue(maximumValue: number): <T extends GenericThing | DataShapeBase, P>(target: T, key: string, descriptor?: TypedPropertyDescriptor<P extends Function ? never : P>) => void;
- 
+/**
+ * When applied to a numeric property or data shape field, this sets the property's maximum value aspect.
+ * @param maximumValue      The maximum value to set. This must be a numeric literal.
+ */
+declare function maximumValue(maximumValue: number): <T extends GenericThing | DataShapeBase, P extends number>(target: T, key: string, descriptor?: TypedPropertyDescriptor<P>) => void;
+
+/**
+ * When applied to a numeric property or data shape field, this sets the property's unit aspect.
+ * @param unit      The unit to use. This must be a string literal.
+ */
+declare function unit(unit: string): <T extends GenericThing | DataShapeBase, P extends number>(target: T, key: string, descriptor?: TypedPropertyDescriptor<P>) => void;
+
 /**
  * When applied to a data shape field, this makes the property a primary key.
  */


### PR DESCRIPTION
Adds support for the `@unit` decorator which can be used to specify a unit for numeric properties. Updates sample entities to demonstrate it.