### PR TITLE
JSON basetype fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 29 Jan 2022
+
+Replaced all instances of the `JSON` type with the `TWJSON` type.
+
+Improved the formatting of the upload response message. Instead of printing out the JSON response that Thingworx provides, the build script will now try to extract and present the relevant information.
+
 # 29 Dec 2021
 
 Added the ability to generate debug builds by using the `--debug` argument.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "bm-thingworx-vscode",
 	"packageName": "bm-thingworx-vscode",
 	"moduleName": "bm-thingworx-vscode",
-	"version": "1.7.0-beta.1",
+	"version": "1.7.1-beta.1",
 	"description": "Develop in ThingWorx with a proper IDE.",
 	"author": "Thingworx RoIcenter",
 	"thingworxProjectName": "MyProject",

--- a/static/base/DefaultEntities.d.ts
+++ b/static/base/DefaultEntities.d.ts
@@ -24,7 +24,7 @@ declare class ApplicationKeyEntity extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -69,7 +69,7 @@ declare class ApplicationKeyEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -94,7 +94,7 @@ declare class ApplicationKeyEntity extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -115,14 +115,14 @@ declare class ApplicationKeyEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -134,7 +134,7 @@ declare class ApplicationKeyEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -201,7 +201,7 @@ declare class ApplicationKeyEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -254,7 +254,7 @@ declare class ApplicationKeyEntity extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -447,7 +447,7 @@ declare class ApplicationKeyEntity extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -468,7 +468,7 @@ declare class ApplicationKeyEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -534,7 +534,7 @@ declare class ApplicationKeyEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -631,7 +631,7 @@ declare class AuthenticatorEntity extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -682,7 +682,7 @@ declare class AuthenticatorEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Returns Provisioning user defaults (e.g. Description, Home Mashup, etc)
@@ -713,7 +713,7 @@ declare class AuthenticatorEntity extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -734,14 +734,14 @@ declare class AuthenticatorEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -753,7 +753,7 @@ declare class AuthenticatorEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Reloads the Resource Provider Scopes
@@ -834,7 +834,7 @@ declare class AuthenticatorEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -881,7 +881,7 @@ declare class AuthenticatorEntity extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -1092,7 +1092,7 @@ declare class AuthenticatorEntity extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Sets users that are excluded during provisioning
@@ -1120,7 +1120,7 @@ declare class AuthenticatorEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -1198,7 +1198,7 @@ declare class AuthenticatorEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -1296,13 +1296,13 @@ declare class ThingShapeEntity<T extends ThingShapeBase> extends RootEntity {
 	 * @param sourcePropertyName Source property name
 	 * @return result
 	 */
-	SetLocalPropertyBinding(args?:{propertyName?: STRING, aspects?: JSON, sourceThingName?: STRING, sourcePropertyName?: STRING}): NOTHING;
+	SetLocalPropertyBinding(args?:{propertyName?: STRING, aspects?: TWJSON, sourceThingName?: STRING, sourcePropertyName?: STRING}): NOTHING;
 
 	/**
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -1366,13 +1366,13 @@ declare class ThingShapeEntity<T extends ThingShapeBase> extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove the remote service binding for a service
@@ -1455,7 +1455,7 @@ declare class ThingShapeEntity<T extends ThingShapeBase> extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a numeric alert parameter
@@ -1531,7 +1531,7 @@ declare class ThingShapeEntity<T extends ThingShapeBase> extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetInstanceRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetInstanceRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Delete all rows from a multi-row configuration table
@@ -1622,7 +1622,7 @@ declare class ThingShapeEntity<T extends ThingShapeBase> extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -1714,7 +1714,7 @@ declare class ThingShapeEntity<T extends ThingShapeBase> extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetInstanceRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetInstanceRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove the remote event binding for a event
@@ -1735,7 +1735,7 @@ declare class ThingShapeEntity<T extends ThingShapeBase> extends RootEntity {
 	 * @param cacheTime Property's cache time value at the server
 	 * @return result
 	 */
-	SetRemotePropertyBinding(args?:{propertyName?: STRING, pushThreshold?: NUMBER, aspects?: JSON, foldType?: STRING, sourcePropertyName?: STRING, timeout?: INTEGER, pushType?: STRING, cacheTime?: INTEGER}): NOTHING;
+	SetRemotePropertyBinding(args?:{propertyName?: STRING, pushThreshold?: NUMBER, aspects?: TWJSON, foldType?: STRING, sourcePropertyName?: STRING, timeout?: INTEGER, pushType?: STRING, cacheTime?: INTEGER}): NOTHING;
 
 	/**
 	 * Get the outgoing dependencies as a network
@@ -1791,7 +1791,7 @@ declare class ThingShapeEntity<T extends ThingShapeBase> extends RootEntity {
 	 * @param dataShape Data shape
 	 * @return result
 	 */
-	AddPropertyDefinition(args?:{defaultValue?: STRING, remoteBindingAspects?: JSON, description?: STRING, readOnly?: BOOLEAN, type?: BASETYPENAME, remote?: BOOLEAN, remotePropertyName?: STRING, timeout?: INTEGER, pushType?: STRING, dataChangeThreshold?: NUMBER, logged?: BOOLEAN, name?: STRING, pushThreshold?: NUMBER, dataChangeType?: STRING, category?: STRING, persistent?: BOOLEAN, dataShape?: DATASHAPENAME}): NOTHING;
+	AddPropertyDefinition(args?:{defaultValue?: STRING, remoteBindingAspects?: TWJSON, description?: STRING, readOnly?: BOOLEAN, type?: BASETYPENAME, remote?: BOOLEAN, remotePropertyName?: STRING, timeout?: INTEGER, pushType?: STRING, dataChangeThreshold?: NUMBER, logged?: BOOLEAN, name?: STRING, pushThreshold?: NUMBER, dataChangeType?: STRING, category?: STRING, persistent?: BOOLEAN, dataShape?: DATASHAPENAME}): NOTHING;
 
 	/**
 	 * Get a numeric alert parameter
@@ -1824,7 +1824,7 @@ declare class ThingShapeEntity<T extends ThingShapeBase> extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Return a list of all the things that implement this shape along with the thing properties and values
@@ -1862,7 +1862,7 @@ declare class ThingShapeEntity<T extends ThingShapeBase> extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get the incoming dependencies as a network
@@ -1892,7 +1892,7 @@ declare class ThingShapeEntity<T extends ThingShapeBase> extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Enable Subscription
@@ -1952,7 +1952,7 @@ declare class ThingShapeEntity<T extends ThingShapeBase> extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove a property definition
@@ -2233,7 +2233,7 @@ declare class ThingShapeEntity<T extends ThingShapeBase> extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -2297,7 +2297,7 @@ declare class ThingShapeEntity<T extends ThingShapeBase> extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -2388,7 +2388,7 @@ declare class DataShapeEntity<T extends DataShapeBase> extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -2440,7 +2440,7 @@ declare class DataShapeEntity<T extends DataShapeBase> extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -2459,7 +2459,7 @@ declare class DataShapeEntity<T extends DataShapeBase> extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -2480,14 +2480,14 @@ declare class DataShapeEntity<T extends DataShapeBase> extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -2499,7 +2499,7 @@ declare class DataShapeEntity<T extends DataShapeBase> extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -2551,7 +2551,7 @@ declare class DataShapeEntity<T extends DataShapeBase> extends RootEntity {
 	 * Get the metadata for this data shape as JSON
 	 * @return Field definitions
 	 */
-	GetDataShapeMetadataAsJSON(args?:{}): JSON;
+	GetDataShapeMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Add a visibility permission
@@ -2585,7 +2585,7 @@ declare class DataShapeEntity<T extends DataShapeBase> extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -2625,7 +2625,7 @@ declare class DataShapeEntity<T extends DataShapeBase> extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -2752,7 +2752,7 @@ declare class DataShapeEntity<T extends DataShapeBase> extends RootEntity {
 	 * Get the effective metadata for this data shape as JSON
 	 * @return Field definitions
 	 */
-	GetEffectiveDataShapeMetadataAsJSON(args?:{}): JSON;
+	GetEffectiveDataShapeMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get the current event definitions for this thing
@@ -2818,7 +2818,7 @@ declare class DataShapeEntity<T extends DataShapeBase> extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Remove a field definition
@@ -2846,7 +2846,7 @@ declare class DataShapeEntity<T extends DataShapeBase> extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -2866,7 +2866,7 @@ declare class DataShapeEntity<T extends DataShapeBase> extends RootEntity {
 	 * @param values Data values (JSON Object)
 	 * @return Created Infotable
 	 */
-	CreateValuesWithData(args?:{values?: JSON}): INFOTABLE<T>;
+	CreateValuesWithData(args?:{values?: TWJSON}): INFOTABLE<T>;
 
 	/**
 	 * Get group permissions
@@ -2912,7 +2912,7 @@ declare class DataShapeEntity<T extends DataShapeBase> extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -3024,7 +3024,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * @param sourcePropertyName Source property name
 	 * @return result
 	 */
-	SetLocalPropertyBinding(args?:{propertyName?: STRING, aspects?: JSON, sourceThingName?: STRING, sourcePropertyName?: STRING}): NOTHING;
+	SetLocalPropertyBinding(args?:{propertyName?: STRING, aspects?: TWJSON, sourceThingName?: STRING, sourcePropertyName?: STRING}): NOTHING;
 
 	/**
 	 * Add a visibility permission
@@ -3038,7 +3038,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -3117,13 +3117,13 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove the remote service binding for a service
@@ -3200,7 +3200,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * Get a list of instance visibility permissions
 	 * @return Permission list
 	 */
-	GetInstanceVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get the mashups related to this thing template
@@ -3212,7 +3212,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a numeric alert parameter
@@ -3308,7 +3308,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetInstanceRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetInstanceRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Delete all rows from a multi-row configuration table
@@ -3424,7 +3424,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Add multiple property definitions at once
@@ -3446,7 +3446,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetInstanceDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetInstanceDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get avatar image url
@@ -3546,7 +3546,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetInstanceRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetInstanceRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove the remote event binding for a event
@@ -3567,7 +3567,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * @param cacheTime Property's cache time value at the server
 	 * @return result
 	 */
-	SetRemotePropertyBinding(args?:{propertyName?: STRING, pushThreshold?: NUMBER, aspects?: JSON, foldType?: STRING, sourcePropertyName?: STRING, timeout?: INTEGER, pushType?: STRING, cacheTime?: INTEGER}): NOTHING;
+	SetRemotePropertyBinding(args?:{propertyName?: STRING, pushThreshold?: NUMBER, aspects?: TWJSON, foldType?: STRING, sourcePropertyName?: STRING, timeout?: INTEGER, pushType?: STRING, cacheTime?: INTEGER}): NOTHING;
 
 	/**
 	 * Get the outgoing dependencies as a network
@@ -3623,7 +3623,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * @param dataShape Data shape
 	 * @return result
 	 */
-	AddPropertyDefinition(args?:{defaultValue?: STRING, remoteBindingAspects?: JSON, description?: STRING, readOnly?: BOOLEAN, type?: BASETYPENAME, remote?: BOOLEAN, remotePropertyName?: STRING, timeout?: INTEGER, pushType?: STRING, dataChangeThreshold?: NUMBER, logged?: BOOLEAN, name?: STRING, pushThreshold?: NUMBER, dataChangeType?: STRING, category?: STRING, persistent?: BOOLEAN, dataShape?: DATASHAPENAME}): NOTHING;
+	AddPropertyDefinition(args?:{defaultValue?: STRING, remoteBindingAspects?: TWJSON, description?: STRING, readOnly?: BOOLEAN, type?: BASETYPENAME, remote?: BOOLEAN, remotePropertyName?: STRING, timeout?: INTEGER, pushType?: STRING, dataChangeThreshold?: NUMBER, logged?: BOOLEAN, name?: STRING, pushThreshold?: NUMBER, dataChangeType?: STRING, category?: STRING, persistent?: BOOLEAN, dataShape?: DATASHAPENAME}): NOTHING;
 
 	/**
 	 * Get a numeric alert parameter
@@ -3656,7 +3656,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Return a list of all the things that implement this template along with the specified thing properties and values
@@ -3694,7 +3694,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get the incoming dependencies as a network
@@ -3724,7 +3724,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Enable Subscription
@@ -3792,7 +3792,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Return a list of all the things that implement this template along with the thing property history
@@ -3944,7 +3944,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * Get a list of instance design time permissions
 	 * @return Permission list
 	 */
-	GetInstanceDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetInstanceDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Has incoming dependencies
@@ -4154,7 +4154,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -4227,7 +4227,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -4269,7 +4269,7 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetInstanceVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetInstanceVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the effective local property binding for a property
@@ -4312,7 +4312,7 @@ declare class ModelTagEntity extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -4364,7 +4364,7 @@ declare class ModelTagEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -4383,7 +4383,7 @@ declare class ModelTagEntity extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -4404,14 +4404,14 @@ declare class ModelTagEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -4423,7 +4423,7 @@ declare class ModelTagEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -4490,7 +4490,7 @@ declare class ModelTagEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Add a new vocabulary term
@@ -4543,7 +4543,7 @@ declare class ModelTagEntity extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -4579,7 +4579,7 @@ declare class ModelTagEntity extends RootEntity {
 	 * @param term Term to match
 	 * @return Vocabulary Term Links
 	 */
-	QueryVocabularyTermLinks(args?:{filter?: STRING, maxItems?: NUMBER, types?: JSON, term?: STRING}): INFOTABLE<EntityDescriptor>;
+	QueryVocabularyTermLinks(args?:{filter?: STRING, maxItems?: NUMBER, types?: TWJSON, term?: STRING}): INFOTABLE<EntityDescriptor>;
 
 	/**
 	 * Get the description for an entity
@@ -4765,7 +4765,7 @@ declare class ModelTagEntity extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -4786,7 +4786,7 @@ declare class ModelTagEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -4845,7 +4845,7 @@ declare class ModelTagEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Return a specific vocabulary term
@@ -4942,7 +4942,7 @@ declare class LogEntity extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -4987,7 +4987,7 @@ declare class LogEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -5006,7 +5006,7 @@ declare class LogEntity extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -5027,14 +5027,14 @@ declare class LogEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -5046,7 +5046,7 @@ declare class LogEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -5115,7 +5115,7 @@ declare class LogEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -5161,7 +5161,7 @@ declare class LogEntity extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -5356,7 +5356,7 @@ declare class LogEntity extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -5377,7 +5377,7 @@ declare class LogEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -5463,7 +5463,7 @@ declare class LogEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Set the Log Level Setting
@@ -5568,7 +5568,7 @@ declare class MediaEntitieEntity extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -5613,7 +5613,7 @@ declare class MediaEntitieEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -5632,7 +5632,7 @@ declare class MediaEntitieEntity extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -5653,14 +5653,14 @@ declare class MediaEntitieEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -5672,7 +5672,7 @@ declare class MediaEntitieEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -5733,7 +5733,7 @@ declare class MediaEntitieEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -5779,7 +5779,7 @@ declare class MediaEntitieEntity extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -5827,7 +5827,7 @@ declare class MediaEntitieEntity extends RootEntity {
 	 * @param relativeURL Relative URL of backend server to stream content from
 	 * @return Stream files from the specified backend system to the specified file in FileRepositoryThing 
 	 */
-	StreamToFileRepository(args?:{headers?: JSON, filePath?: STRING, fileRepositoryThing?: THINGNAME, relativeURL?: STRING}): JSON;
+	StreamToFileRepository(args?:{headers?: TWJSON, filePath?: STRING, fileRepositoryThing?: THINGNAME, relativeURL?: STRING}): TWJSON;
 
 	/**
 	 * Has incoming dependencies
@@ -5969,7 +5969,7 @@ declare class MediaEntitieEntity extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -5990,7 +5990,7 @@ declare class MediaEntitieEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -6028,7 +6028,7 @@ declare class MediaEntitieEntity extends RootEntity {
 	 * @param relativeURL Relative URL of backend server to stream content to
 	 * @return Stream the specified file from FileRepositoryThing 
 	 */
-	StreamFromFileRepository(args?:{headers?: JSON, filePath?: STRING, fileRepositoryThing?: THINGNAME, relativeURL?: STRING}): JSON;
+	StreamFromFileRepository(args?:{headers?: TWJSON, filePath?: STRING, fileRepositoryThing?: THINGNAME, relativeURL?: STRING}): TWJSON;
 
 	/**
 	 * Delete a design time permission
@@ -6065,7 +6065,7 @@ declare class MediaEntitieEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -6164,7 +6164,7 @@ declare class MenuEntity extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -6215,7 +6215,7 @@ declare class MenuEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -6234,7 +6234,7 @@ declare class MenuEntity extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -6255,14 +6255,14 @@ declare class MenuEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -6274,7 +6274,7 @@ declare class MenuEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -6341,7 +6341,7 @@ declare class MenuEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -6381,7 +6381,7 @@ declare class MenuEntity extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -6555,7 +6555,7 @@ declare class MenuEntity extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -6576,7 +6576,7 @@ declare class MenuEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -6635,7 +6635,7 @@ declare class MenuEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -6725,7 +6725,7 @@ declare class MashupEntity extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -6770,7 +6770,7 @@ declare class MashupEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -6795,7 +6795,7 @@ declare class MashupEntity extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get preview image
@@ -6822,14 +6822,14 @@ declare class MashupEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -6841,7 +6841,7 @@ declare class MashupEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -6902,7 +6902,7 @@ declare class MashupEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -6942,7 +6942,7 @@ declare class MashupEntity extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -7122,7 +7122,7 @@ declare class MashupEntity extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -7143,7 +7143,7 @@ declare class MashupEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -7208,7 +7208,7 @@ declare class MashupEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Return a list of related thing templates
@@ -7316,7 +7316,7 @@ declare class StyleDefinitionEntity extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -7361,7 +7361,7 @@ declare class StyleDefinitionEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -7380,7 +7380,7 @@ declare class StyleDefinitionEntity extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -7401,14 +7401,14 @@ declare class StyleDefinitionEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -7420,7 +7420,7 @@ declare class StyleDefinitionEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -7481,7 +7481,7 @@ declare class StyleDefinitionEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -7521,7 +7521,7 @@ declare class StyleDefinitionEntity extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -7695,7 +7695,7 @@ declare class StyleDefinitionEntity extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -7716,7 +7716,7 @@ declare class StyleDefinitionEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -7775,7 +7775,7 @@ declare class StyleDefinitionEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -7865,7 +7865,7 @@ declare class StateDefinitionEntity extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -7910,7 +7910,7 @@ declare class StateDefinitionEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -7929,7 +7929,7 @@ declare class StateDefinitionEntity extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -7950,14 +7950,14 @@ declare class StateDefinitionEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -7969,7 +7969,7 @@ declare class StateDefinitionEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -8030,7 +8030,7 @@ declare class StateDefinitionEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -8070,7 +8070,7 @@ declare class StateDefinitionEntity extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -8244,7 +8244,7 @@ declare class StateDefinitionEntity extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -8265,7 +8265,7 @@ declare class StateDefinitionEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -8324,7 +8324,7 @@ declare class StateDefinitionEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -8421,7 +8421,7 @@ declare class LocalizationTableEntity extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -8474,7 +8474,7 @@ declare class LocalizationTableEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -8493,7 +8493,7 @@ declare class LocalizationTableEntity extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -8514,14 +8514,14 @@ declare class LocalizationTableEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -8533,7 +8533,7 @@ declare class LocalizationTableEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -8594,7 +8594,7 @@ declare class LocalizationTableEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -8634,7 +8634,7 @@ declare class LocalizationTableEntity extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -8822,7 +8822,7 @@ declare class LocalizationTableEntity extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -8843,7 +8843,7 @@ declare class LocalizationTableEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -8923,7 +8923,7 @@ declare class LocalizationTableEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -9029,7 +9029,7 @@ declare class OrganizationEntity<T extends string = string> extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -9074,7 +9074,7 @@ declare class OrganizationEntity<T extends string = string> extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -9093,7 +9093,7 @@ declare class OrganizationEntity<T extends string = string> extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -9114,7 +9114,7 @@ declare class OrganizationEntity<T extends string = string> extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Add a user/group to this organization
@@ -9130,7 +9130,7 @@ declare class OrganizationEntity<T extends string = string> extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -9142,7 +9142,7 @@ declare class OrganizationEntity<T extends string = string> extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -9224,7 +9224,7 @@ declare class OrganizationEntity<T extends string = string> extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check if the parent of a given organizational unit in the organization matches a specific name
@@ -9279,7 +9279,7 @@ declare class OrganizationEntity<T extends string = string> extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove a user/organization from this organization
@@ -9339,7 +9339,7 @@ declare class OrganizationEntity<T extends string = string> extends RootEntity {
 	 * @param name Organizational Unit name
 	 * @return Organization Members
 	 */
-	QueryMembers(args?:{filter?: STRING, maxItems?: NUMBER, types?: JSON, name?: STRING}): INFOTABLE<EntityReferenceWithDescription>;
+	QueryMembers(args?:{filter?: STRING, maxItems?: NUMBER, types?: TWJSON, name?: STRING}): INFOTABLE<EntityReferenceWithDescription>;
 
 	/**
 	 * Get the description for an entity
@@ -9525,7 +9525,7 @@ declare class OrganizationEntity<T extends string = string> extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Add an organizational unit
@@ -9554,7 +9554,7 @@ declare class OrganizationEntity<T extends string = string> extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -9636,7 +9636,7 @@ declare class OrganizationEntity<T extends string = string> extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Return a list of all the parent connections in this organization for a specific node
@@ -9740,7 +9740,7 @@ declare class UserEntity extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -9783,13 +9783,13 @@ declare class UserEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific user
@@ -9825,7 +9825,7 @@ declare class UserEntity extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Add a run time permission
@@ -9864,7 +9864,7 @@ declare class UserEntity extends RootEntity {
 	 * @param name Parameter name
 	 * @return Parameter value
 	 */
-	GetPersistentValue(args?:{name?: STRING}): JSON;
+	GetPersistentValue(args?:{name?: STRING}): TWJSON;
 
 	/**
 	 * Change password
@@ -9925,7 +9925,7 @@ declare class UserEntity extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -10006,7 +10006,7 @@ declare class UserEntity extends RootEntity {
 	 * @param value Parameter value
 	 * @return result
 	 */
-	SetPersistentValue(args?:{name?: STRING, value?: JSON}): NOTHING;
+	SetPersistentValue(args?:{name?: STRING, value?: TWJSON}): NOTHING;
 
 	/**
 	 * Get summary information
@@ -10069,7 +10069,7 @@ declare class UserEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -10088,7 +10088,7 @@ declare class UserEntity extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get the incoming dependencies as a network
@@ -10103,7 +10103,7 @@ declare class UserEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -10164,7 +10164,7 @@ declare class UserEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -10370,7 +10370,7 @@ declare class UserEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -10414,7 +10414,7 @@ declare class UserEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -10485,7 +10485,7 @@ declare class GroupEntity extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -10530,7 +10530,7 @@ declare class GroupEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -10549,7 +10549,7 @@ declare class GroupEntity extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -10570,7 +10570,7 @@ declare class GroupEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Add a user/group to this group
@@ -10585,7 +10585,7 @@ declare class GroupEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -10597,7 +10597,7 @@ declare class GroupEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -10658,7 +10658,7 @@ declare class GroupEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -10698,7 +10698,7 @@ declare class GroupEntity extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove a user/group from this group
@@ -10816,7 +10816,7 @@ declare class GroupEntity extends RootEntity {
 	 * @param types Entity types
 	 * @return Group Members
 	 */
-	QueryGroupMembers(args?:{filter?: STRING, maxItems?: NUMBER, types?: JSON}): INFOTABLE<GroupMember>;
+	QueryGroupMembers(args?:{filter?: STRING, maxItems?: NUMBER, types?: TWJSON}): INFOTABLE<GroupMember>;
 
 	/**
 	 * Get home mashup
@@ -10902,7 +10902,7 @@ declare class GroupEntity extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get list of organizational units that this group is a member of
@@ -10929,7 +10929,7 @@ declare class GroupEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -10994,7 +10994,7 @@ declare class GroupEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -11082,7 +11082,7 @@ declare class PersistenceProviderEntity extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -11131,13 +11131,13 @@ declare class PersistenceProviderEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Does the persistence provider's package support Stream processing
@@ -11197,7 +11197,7 @@ declare class PersistenceProviderEntity extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Add a run time permission
@@ -11284,7 +11284,7 @@ declare class PersistenceProviderEntity extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -11386,7 +11386,7 @@ declare class PersistenceProviderEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -11405,7 +11405,7 @@ declare class PersistenceProviderEntity extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get the incoming dependencies as a network
@@ -11420,7 +11420,7 @@ declare class PersistenceProviderEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -11499,7 +11499,7 @@ declare class PersistenceProviderEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -11694,7 +11694,7 @@ declare class PersistenceProviderEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -11743,7 +11743,7 @@ declare class PersistenceProviderEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check whether the persistence provider is the default for data providers
@@ -11838,7 +11838,7 @@ declare class ProjectEntity extends RootEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -11883,7 +11883,7 @@ declare class ProjectEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -11909,7 +11909,7 @@ declare class ProjectEntity extends RootEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -11930,14 +11930,14 @@ declare class ProjectEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -11949,7 +11949,7 @@ declare class ProjectEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -12010,7 +12010,7 @@ declare class ProjectEntity extends RootEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -12050,7 +12050,7 @@ declare class ProjectEntity extends RootEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -12242,7 +12242,7 @@ declare class ProjectEntity extends RootEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -12263,7 +12263,7 @@ declare class ProjectEntity extends RootEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -12285,7 +12285,7 @@ declare class ProjectEntity extends RootEntity {
 	 * @param tags Tags
 	 * @return result
 	 */
-	AddEntities(args?:{searchExpression?: STRING, types?: JSON, tags?: TAGS}): NOTHING;
+	AddEntities(args?:{searchExpression?: STRING, types?: TWJSON, tags?: TAGS}): NOTHING;
 
 	/**
 	 * Get group permissions
@@ -12343,7 +12343,7 @@ declare class ProjectEntity extends RootEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -18730,7 +18730,7 @@ declare const Projects: Projects;
 	/**
 	 * 
 	 */
-	element: JSON;
+	element: TWJSON;
 
 
 }
@@ -19601,7 +19601,7 @@ declare const Projects: Projects;
 	/**
 	 * For remote properties only: Remote binding aspects
 	 */
-	remoteBindingAspects: JSON;
+	remoteBindingAspects: TWJSON;
 
 	/**
 	 * Flag indicating whether or not this property is bound to a remote property
@@ -19729,7 +19729,7 @@ declare const Projects: Projects;
 	/**
 	 * Used-In information of dependent entity
 	 */
-	whereUsed: JSON;
+	whereUsed: TWJSON;
 
 	/**
 	 * Dependent entity last modified
@@ -19920,7 +19920,7 @@ declare const Projects: Projects;
 	/**
 	 * Remote binding aspects
 	 */
-	aspects: JSON;
+	aspects: TWJSON;
 
 	/**
 	 * Bound item name
@@ -23664,7 +23664,7 @@ declare const Projects: Projects;
 	/**
 	 * Filters for this query
 	 */
-	filters: JSON;
+	filters: TWJSON;
 
 	/**
 	 * Mashup results
@@ -23781,7 +23781,7 @@ declare const Projects: Projects;
 	/**
 	 * Metadata associated with this transfer
 	 */
-	metadata: JSON;
+	metadata: TWJSON;
 
 	/**
 	 * MD5 checksum of the target file
@@ -26372,7 +26372,7 @@ declare const Projects: Projects;
 	/**
 	 * Remote binding aspects
 	 */
-	aspects: JSON;
+	aspects: TWJSON;
 
 	/**
 	 * Bound item name
@@ -27035,7 +27035,7 @@ declare const Projects: Projects;
 	/**
 	 * Aspects of the binding
 	 */
-	aspects: JSON;
+	aspects: TWJSON;
 
 	/**
 	 * Change threshold to generate event for numeric properties

--- a/static/base/Globals.d.ts
+++ b/static/base/Globals.d.ts
@@ -176,7 +176,7 @@ declare function enableDiagnosticTrace(): BOOLEAN;
  * @param value String value
  * @return Decoded value as JSON array
  */
-declare function base64DecodeBytes(value?: STRING): JSON;
+declare function base64DecodeBytes(value?: STRING): TWJSON;
 
 
 /**
@@ -184,7 +184,7 @@ declare function base64DecodeBytes(value?: STRING): JSON;
  * @param value Array value
  * @return Encoded value
  */
-declare function base64EncodeBytes(value?: JSON): STRING;
+declare function base64EncodeBytes(value?: TWJSON): STRING;
 
 
 /**

--- a/static/base/Resources.d.ts
+++ b/static/base/Resources.d.ts
@@ -30,7 +30,7 @@ declare class DeviceFunctions extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -83,7 +83,7 @@ declare class DeviceFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -102,7 +102,7 @@ declare class DeviceFunctions extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -123,14 +123,14 @@ declare class DeviceFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -142,7 +142,7 @@ declare class DeviceFunctions extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -210,7 +210,7 @@ declare class DeviceFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -250,7 +250,7 @@ declare class DeviceFunctions extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -424,7 +424,7 @@ declare class DeviceFunctions extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get unbound federated things
@@ -453,7 +453,7 @@ declare class DeviceFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -512,7 +512,7 @@ declare class DeviceFunctions extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -619,7 +619,7 @@ declare class SecurityServices extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -664,7 +664,7 @@ declare class SecurityServices extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -683,7 +683,7 @@ declare class SecurityServices extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -704,14 +704,14 @@ declare class SecurityServices extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -723,7 +723,7 @@ declare class SecurityServices extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -784,7 +784,7 @@ declare class SecurityServices extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -833,7 +833,7 @@ declare class SecurityServices extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -1025,7 +1025,7 @@ declare class SecurityServices extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -1046,7 +1046,7 @@ declare class SecurityServices extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -1113,7 +1113,7 @@ declare class SecurityServices extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -1209,7 +1209,7 @@ declare class RuntimeLocalizationFunctions extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -1254,7 +1254,7 @@ declare class RuntimeLocalizationFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -1273,7 +1273,7 @@ declare class RuntimeLocalizationFunctions extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -1294,14 +1294,14 @@ declare class RuntimeLocalizationFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -1313,7 +1313,7 @@ declare class RuntimeLocalizationFunctions extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -1374,7 +1374,7 @@ declare class RuntimeLocalizationFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -1414,7 +1414,7 @@ declare class RuntimeLocalizationFunctions extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -1616,7 +1616,7 @@ declare class RuntimeLocalizationFunctions extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -1637,7 +1637,7 @@ declare class RuntimeLocalizationFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -1702,7 +1702,7 @@ declare class RuntimeLocalizationFunctions extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -1783,7 +1783,7 @@ declare class EntityServices extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -1872,13 +1872,13 @@ declare class EntityServices extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Add a thing shape to an existing thing
@@ -1937,7 +1937,7 @@ declare class EntityServices extends ResourceEntity {
 	 * @param tags Tags
 	 * @return result
 	 */
-	CreateStyleDefinition(args?:{name?: STRING, description?: STRING, projectName?: PROJECTNAME, content?: JSON, tags?: TAGS}): NOTHING;
+	CreateStyleDefinition(args?:{name?: STRING, description?: STRING, projectName?: PROJECTNAME, content?: TWJSON, tags?: TAGS}): NOTHING;
 
 	/**
 	 * Delete a style definition
@@ -1998,7 +1998,7 @@ declare class EntityServices extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete a user
@@ -2163,7 +2163,7 @@ declare class EntityServices extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Set run time permissions on a set of entities
@@ -2436,7 +2436,7 @@ declare class EntityServices extends ResourceEntity {
 	 * @param type Entity Collection Type (Things, Mashups, Users, etc)
 	 * @return Entity definition
 	 */
-	ReadEntityDefinitionAsJSON(args?:{name?: STRING, type?: STRING}): JSON;
+	ReadEntityDefinitionAsJSON(args?:{name?: STRING, type?: STRING}): TWJSON;
 
 	/**
 	 * Delete a thing shape
@@ -2517,13 +2517,13 @@ declare class EntityServices extends ResourceEntity {
 	 * @param key Encryption-Decryption key name
 	 * @return Entity definition
 	 */
-	ReadEntityAsJSON(args?:{name?: STRING, type?: STRING, key?: STRING}): JSON;
+	ReadEntityAsJSON(args?:{name?: STRING, type?: STRING, key?: STRING}): TWJSON;
 
 	/**
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Restart dependencies for an existing thing template
@@ -2549,7 +2549,7 @@ declare class EntityServices extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get the incoming dependencies as a network
@@ -2564,7 +2564,7 @@ declare class EntityServices extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -2635,7 +2635,7 @@ declare class EntityServices extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -2725,7 +2725,7 @@ declare class EntityServices extends ResourceEntity {
 	 * @param content Style definition content in JSON format
 	 * @return result
 	 */
-	UpdateStyleDefinition(args?:{name?: STYLEDEFINITIONNAME, content?: JSON}): NOTHING;
+	UpdateStyleDefinition(args?:{name?: STYLEDEFINITIONNAME, content?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the description for an entity
@@ -2972,7 +2972,7 @@ declare class EntityServices extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -3019,7 +3019,7 @@ declare class EntityServices extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Create a new model tag vocabulary
@@ -3128,7 +3128,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -3173,7 +3173,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -3192,7 +3192,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -3213,14 +3213,14 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -3232,7 +3232,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -3276,7 +3276,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param tags Tags
 	 * @return Matching entries
 	 */
-	SearchModelEntities(args?:{maxItems?: NUMBER, searchExpression?: STRING, types?: JSON, aspects?: JSON, excludedAspects?: JSON, maxSearchItems?: NUMBER, tags?: TAGS}): INFOTABLE<EntityDescriptor>;
+	SearchModelEntities(args?:{maxItems?: NUMBER, searchExpression?: STRING, types?: TWJSON, aspects?: TWJSON, excludedAspects?: TWJSON, maxSearchItems?: NUMBER, tags?: TAGS}): INFOTABLE<EntityDescriptor>;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific user
@@ -3295,7 +3295,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param term Term to search
 	 * @return Search Results
 	 */
-	SearchDataTagTerm(args?:{maxItems?: NUMBER, types?: JSON, names?: JSON, term?: STRING}): INFOTABLE<EntityDescriptor>;
+	SearchDataTagTerm(args?:{maxItems?: NUMBER, types?: TWJSON, names?: TWJSON, term?: STRING}): INFOTABLE<EntityDescriptor>;
 
 	/**
 	 * Add a visibility permission
@@ -3316,7 +3316,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -3356,7 +3356,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -3410,7 +3410,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param startDate Only return entities modified since this date
 	 * @return Matching entries
 	 */
-	SpotlightSearch(args?:{maxItems?: NUMBER, searchExpression?: STRING, types?: JSON, withPermissions?: BOOLEAN, endDate?: DATETIME, aspects?: JSON, excludedAspects?: JSON, tags?: TAGS, thingTemplates?: JSON, searchDescriptions?: BOOLEAN, thingShapes?: JSON, sortBy?: STRING, isAscending?: BOOLEAN, projectName?: PROJECTNAME, maxSearchItems?: NUMBER, startDate?: DATETIME}): INFOTABLE<SpotlightSearch>;
+	SpotlightSearch(args?:{maxItems?: NUMBER, searchExpression?: STRING, types?: TWJSON, withPermissions?: BOOLEAN, endDate?: DATETIME, aspects?: TWJSON, excludedAspects?: TWJSON, tags?: TAGS, thingTemplates?: TWJSON, searchDescriptions?: BOOLEAN, thingShapes?: TWJSON, sortBy?: STRING, isAscending?: BOOLEAN, projectName?: PROJECTNAME, maxSearchItems?: NUMBER, startDate?: DATETIME}): INFOTABLE<SpotlightSearch>;
 
 	/**
 	 * Retrieve a list of all collaboration entries filtered by keyword query and optional date range
@@ -3427,7 +3427,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param startDate Start time
 	 * @return Matching entries
 	 */
-	SearchCollaboration(args?:{dataTags?: TAGS, maxItems?: NUMBER, searchExpression?: STRING, types?: JSON, names?: JSON, sourceTags?: TAGS, sources?: JSON, modelTags?: TAGS, endDate?: DATETIME, maxSearchItems?: NUMBER, startDate?: DATETIME}): INFOTABLE<SearchResults>;
+	SearchCollaboration(args?:{dataTags?: TAGS, maxItems?: NUMBER, searchExpression?: STRING, types?: TWJSON, names?: TWJSON, sourceTags?: TAGS, sources?: TWJSON, modelTags?: TAGS, endDate?: DATETIME, maxSearchItems?: NUMBER, startDate?: DATETIME}): INFOTABLE<SearchResults>;
 
 	/**
 	 * Search data tag index for matches
@@ -3436,7 +3436,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param tags Tags to search
 	 * @return Search Results
 	 */
-	SearchDataTags(args?:{maxItems?: NUMBER, types?: JSON, tags?: TAGS}): INFOTABLE<EntityDescriptor>;
+	SearchDataTags(args?:{maxItems?: NUMBER, types?: TWJSON, tags?: TAGS}): INFOTABLE<EntityDescriptor>;
 
 	/**
 	 * Return a list of all the things that implement this template, including transient Things
@@ -3456,7 +3456,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param maxSearchItems Maximum number of items to search
 	 * @return Search Results
 	 */
-	SearchVocabularyTerms(args?:{maxItems?: NUMBER, searchExpression?: STRING, names?: JSON, type?: STRING, maxSearchItems?: NUMBER}): INFOTABLE<SearchResults>;
+	SearchVocabularyTerms(args?:{maxItems?: NUMBER, searchExpression?: STRING, names?: TWJSON, type?: STRING, maxSearchItems?: NUMBER}): INFOTABLE<SearchResults>;
 
 	/**
 	 * Has incoming dependencies
@@ -3485,7 +3485,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param tags Tags to search
 	 * @return Search Results
 	 */
-	SearchModelTags(args?:{maxItems?: NUMBER, types?: JSON, aspects?: JSON, excludedAspects?: JSON, tags?: TAGS}): INFOTABLE<EntityDescriptor>;
+	SearchModelTags(args?:{maxItems?: NUMBER, types?: TWJSON, aspects?: TWJSON, excludedAspects?: TWJSON, tags?: TAGS}): INFOTABLE<EntityDescriptor>;
 
 	/**
 	 * Search model tag index for matches based on a term
@@ -3506,7 +3506,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param tags Tags
 	 * @return Matching entries
 	 */
-	SearchModelEntitiesWithRestrictions(args?:{maxItems?: NUMBER, searchExpression?: STRING, types?: JSON, aspects?: JSON, excludedAspects?: JSON, maxSearchItems?: NUMBER, tags?: TAGS}): INFOTABLE<EntityDescriptor>;
+	SearchModelEntitiesWithRestrictions(args?:{maxItems?: NUMBER, searchExpression?: STRING, types?: TWJSON, aspects?: TWJSON, excludedAspects?: TWJSON, maxSearchItems?: NUMBER, tags?: TAGS}): INFOTABLE<EntityDescriptor>;
 
 	/**
 	 * Get the current service definitions for this thing
@@ -3593,7 +3593,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param maxSearchItems Maximum number of items to search
 	 * @return Search Results
 	 */
-	SearchThings(args?:{maxItems?: NUMBER, searchExpression?: STRING, types?: JSON, thingTemplates?: JSON, identifierSearchExpression?: STRING, modelTags?: TAGS, thingShapes?: JSON, query?: QUERY, aspects?: JSON, excludedAspects?: JSON, networks?: JSON, maxSearchItems?: NUMBER}): INFOTABLE<SearchResults>;
+	SearchThings(args?:{maxItems?: NUMBER, searchExpression?: STRING, types?: TWJSON, thingTemplates?: TWJSON, identifierSearchExpression?: STRING, modelTags?: TAGS, thingShapes?: TWJSON, query?: QUERY, aspects?: TWJSON, excludedAspects?: TWJSON, networks?: TWJSON, maxSearchItems?: NUMBER}): INFOTABLE<SearchResults>;
 
 	/**
 	 * Search model tag index for matches based on a term
@@ -3603,7 +3603,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param term Term to search
 	 * @return Search Results
 	 */
-	SearchModelTagTerm(args?:{maxItems?: NUMBER, types?: JSON, names?: JSON, term?: STRING}): INFOTABLE<EntityDescriptor>;
+	SearchModelTagTerm(args?:{maxItems?: NUMBER, types?: TWJSON, names?: TWJSON, term?: STRING}): INFOTABLE<EntityDescriptor>;
 
 	/**
 	 * Get the current event definitions for this thing
@@ -3623,7 +3623,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param maxSearchItems Maximum number of items to search
 	 * @return Search Results
 	 */
-	SearchAll(args?:{dataTags?: TAGS, maxItems?: NUMBER, searchExpression?: STRING, types?: JSON, modelTags?: TAGS, maxSearchItems?: NUMBER}): INFOTABLE<SearchResults>;
+	SearchAll(args?:{dataTags?: TAGS, maxItems?: NUMBER, searchExpression?: STRING, types?: TWJSON, modelTags?: TAGS, maxSearchItems?: NUMBER}): INFOTABLE<SearchResults>;
 
 	/**
 	 * Return a list of all the things that implement this template and their data
@@ -3692,7 +3692,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -3713,7 +3713,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Search everything matches based on a term
@@ -3731,7 +3731,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param startDate Start time
 	 * @return Search Results
 	 */
-	SearchData(args?:{dataShapes?: JSON, dataTags?: TAGS, dataTypes?: JSON, maxItems?: NUMBER, searchExpression?: STRING, names?: JSON, sources?: JSON, sourceTags?: TAGS, modelTags?: TAGS, endDate?: DATETIME, maxSearchItems?: NUMBER, startDate?: DATETIME}): INFOTABLE<SearchResults>;
+	SearchData(args?:{dataShapes?: TWJSON, dataTags?: TAGS, dataTypes?: TWJSON, maxItems?: NUMBER, searchExpression?: STRING, names?: TWJSON, sources?: TWJSON, sourceTags?: TAGS, modelTags?: TAGS, endDate?: DATETIME, maxSearchItems?: NUMBER, startDate?: DATETIME}): INFOTABLE<SearchResults>;
 
 	/**
 	 * Has outgoing dependencies
@@ -3782,7 +3782,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param maxSearchItems Maximum number of items to search
 	 * @return Search Results
 	 */
-	SearchMashups(args?:{maxItems?: NUMBER, searchExpression?: STRING, thingTemplates?: JSON, modelTags?: TAGS, thingShapes?: JSON, aspects?: JSON, excludedAspects?: JSON, maxSearchItems?: NUMBER}): INFOTABLE<SearchResults>;
+	SearchMashups(args?:{maxItems?: NUMBER, searchExpression?: STRING, thingTemplates?: TWJSON, modelTags?: TAGS, thingShapes?: TWJSON, aspects?: TWJSON, excludedAspects?: TWJSON, maxSearchItems?: NUMBER}): INFOTABLE<SearchResults>;
 
 	/**
 	 * Get the difference between this entity and another
@@ -3804,7 +3804,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -3824,7 +3824,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param maxSearchItems Maximum number of items to search
 	 * @return Search Results
 	 */
-	SearchPeople(args?:{maxItems?: NUMBER, searchExpression?: STRING, modelTags?: TAGS, query?: QUERY, aspects?: JSON, excludedAspects?: JSON, maxSearchItems?: NUMBER}): INFOTABLE<SearchResults>;
+	SearchPeople(args?:{maxItems?: NUMBER, searchExpression?: STRING, modelTags?: TAGS, query?: QUERY, aspects?: TWJSON, excludedAspects?: TWJSON, maxSearchItems?: NUMBER}): INFOTABLE<SearchResults>;
 
 	/**
 	 * Get the metadata in InfoTable format
@@ -3890,7 +3890,7 @@ declare class SearchFunctions extends ResourceEntity {
 	 * @param maxSearchItems Maximum number of items to search
 	 * @return Search Results
 	 */
-	SearchTags(args?:{maxItems?: NUMBER, searchExpression?: STRING, types?: JSON, names?: JSON, maxSearchItems?: NUMBER}): INFOTABLE<SearchResults>;
+	SearchTags(args?:{maxItems?: NUMBER, searchExpression?: STRING, types?: TWJSON, names?: TWJSON, maxSearchItems?: NUMBER}): INFOTABLE<SearchResults>;
 
 	/**
 	 * Get user permissions
@@ -3925,7 +3925,7 @@ declare class NotificationServices extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -3970,7 +3970,7 @@ declare class NotificationServices extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -3989,7 +3989,7 @@ declare class NotificationServices extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -4010,14 +4010,14 @@ declare class NotificationServices extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -4029,7 +4029,7 @@ declare class NotificationServices extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -4101,7 +4101,7 @@ declare class NotificationServices extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -4141,7 +4141,7 @@ declare class NotificationServices extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -4315,7 +4315,7 @@ declare class NotificationServices extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -4336,7 +4336,7 @@ declare class NotificationServices extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -4395,7 +4395,7 @@ declare class NotificationServices extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -4493,7 +4493,7 @@ declare class InfoTableFunctions extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -4551,13 +4551,13 @@ declare class InfoTableFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Not equal filter
@@ -4629,7 +4629,7 @@ declare class InfoTableFunctions extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Pattern matching filter
@@ -4761,7 +4761,7 @@ declare class InfoTableFunctions extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -4895,7 +4895,7 @@ declare class InfoTableFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -4927,7 +4927,7 @@ declare class InfoTableFunctions extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Convert an info table into JSON
@@ -4949,7 +4949,7 @@ declare class InfoTableFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -5019,7 +5019,7 @@ declare class InfoTableFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -5231,7 +5231,7 @@ declare class InfoTableFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -5268,7 +5268,7 @@ declare class InfoTableFunctions extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Less than filter
@@ -5347,7 +5347,7 @@ declare class EncryptionServices extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -5392,7 +5392,7 @@ declare class EncryptionServices extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -5411,7 +5411,7 @@ declare class EncryptionServices extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Returns decrypted data using the Base64 encoded key with valid sizes; 128, 192 or 256 bits
@@ -5440,14 +5440,14 @@ declare class EncryptionServices extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -5459,7 +5459,7 @@ declare class EncryptionServices extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -5520,7 +5520,7 @@ declare class EncryptionServices extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -5560,7 +5560,7 @@ declare class EncryptionServices extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Returns an encrypted password
@@ -5748,7 +5748,7 @@ declare class EncryptionServices extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Returns an decrypted string using a specified key
@@ -5777,7 +5777,7 @@ declare class EncryptionServices extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -5844,7 +5844,7 @@ declare class EncryptionServices extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -5948,7 +5948,7 @@ declare class SourceControlFunctions extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -6019,7 +6019,7 @@ declare class SourceControlFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -6038,7 +6038,7 @@ declare class SourceControlFunctions extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -6059,14 +6059,14 @@ declare class SourceControlFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -6078,7 +6078,7 @@ declare class SourceControlFunctions extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -6139,7 +6139,7 @@ declare class SourceControlFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -6179,7 +6179,7 @@ declare class SourceControlFunctions extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -6353,7 +6353,7 @@ declare class SourceControlFunctions extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Export a list of entities for source control
@@ -6388,7 +6388,7 @@ declare class SourceControlFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -6456,7 +6456,7 @@ declare class SourceControlFunctions extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -6554,7 +6554,7 @@ declare class ScriptServices extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -6599,7 +6599,7 @@ declare class ScriptServices extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -6618,7 +6618,7 @@ declare class ScriptServices extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -6639,14 +6639,14 @@ declare class ScriptServices extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -6658,7 +6658,7 @@ declare class ScriptServices extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Validate script syntax
@@ -6726,7 +6726,7 @@ declare class ScriptServices extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Validate script syntax, returns with the line and column number
@@ -6773,7 +6773,7 @@ declare class ScriptServices extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -6947,7 +6947,7 @@ declare class ScriptServices extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -6968,7 +6968,7 @@ declare class ScriptServices extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -7027,7 +7027,7 @@ declare class ScriptServices extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -7116,7 +7116,7 @@ declare class CollectionFunctions extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -7161,7 +7161,7 @@ declare class CollectionFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete a run time permission
@@ -7191,7 +7191,7 @@ declare class CollectionFunctions extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -7212,14 +7212,14 @@ declare class CollectionFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -7231,7 +7231,7 @@ declare class CollectionFunctions extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -7306,7 +7306,7 @@ declare class CollectionFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -7360,7 +7360,7 @@ declare class CollectionFunctions extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -7566,7 +7566,7 @@ declare class CollectionFunctions extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Import permissions for entities and collections
@@ -7596,7 +7596,7 @@ declare class CollectionFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -7665,7 +7665,7 @@ declare class CollectionFunctions extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -7784,7 +7784,7 @@ declare class CurrentSessionInfo extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -7829,7 +7829,7 @@ declare class CurrentSessionInfo extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Terminate all active sessions for a user
@@ -7863,7 +7863,7 @@ declare class CurrentSessionInfo extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -7884,14 +7884,14 @@ declare class CurrentSessionInfo extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -7903,7 +7903,7 @@ declare class CurrentSessionInfo extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -7976,7 +7976,7 @@ declare class CurrentSessionInfo extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -8024,7 +8024,7 @@ declare class CurrentSessionInfo extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -8113,7 +8113,7 @@ declare class CurrentSessionInfo extends ResourceEntity {
 	 * @param value Parameter value
 	 * @return result
 	 */
-	SetGlobalSessionJSONValue(args?:{name?: STRING, value?: JSON}): NOTHING;
+	SetGlobalSessionJSONValue(args?:{name?: STRING, value?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the license declined text
@@ -8252,7 +8252,7 @@ declare class CurrentSessionInfo extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -8273,7 +8273,7 @@ declare class CurrentSessionInfo extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -8363,7 +8363,7 @@ declare class CurrentSessionInfo extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -8453,7 +8453,7 @@ declare class DashboardFunctions extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -8504,13 +8504,13 @@ declare class DashboardFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific user
@@ -8557,7 +8557,7 @@ declare class DashboardFunctions extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Add a run time permission
@@ -8694,7 +8694,7 @@ declare class DashboardFunctions extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -8808,7 +8808,7 @@ declare class DashboardFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -8827,7 +8827,7 @@ declare class DashboardFunctions extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get the incoming dependencies as a network
@@ -8842,7 +8842,7 @@ declare class DashboardFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -8900,7 +8900,7 @@ declare class DashboardFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -9111,7 +9111,7 @@ declare class DashboardFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -9157,7 +9157,7 @@ declare class DashboardFunctions extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -9250,7 +9250,7 @@ declare class AlertFunctions extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -9301,7 +9301,7 @@ declare class AlertFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -9320,7 +9320,7 @@ declare class AlertFunctions extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -9341,14 +9341,14 @@ declare class AlertFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -9360,7 +9360,7 @@ declare class AlertFunctions extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -9421,7 +9421,7 @@ declare class AlertFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -9478,7 +9478,7 @@ declare class AlertFunctions extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Purge the alert history
@@ -9716,7 +9716,7 @@ declare class AlertFunctions extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -9737,7 +9737,7 @@ declare class AlertFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -9796,7 +9796,7 @@ declare class AlertFunctions extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -9884,7 +9884,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return result
 	 */
-	Delete(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): NOTHING;
+	Delete(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): NOTHING;
 
 	/**
 	 * Get the outgoing dependencies as a network
@@ -9913,7 +9913,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as XML document
 	 */
-	PutXML(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: XML, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): XML;
+	PutXML(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: XML, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): XML;
 
 	/**
 	 * Get ann event definitions for this thing
@@ -9926,7 +9926,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -9956,7 +9956,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as text content
 	 */
-	LoadText(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, appendHeader?: BOOLEAN, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): STRING;
+	LoadText(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, appendHeader?: BOOLEAN, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): STRING;
 
 	/**
 	 * Set an entire multi-row configuration table
@@ -9992,7 +9992,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -10011,7 +10011,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -10032,14 +10032,14 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -10051,7 +10051,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Issue a URL call and get the returned cookies back
@@ -10070,7 +10070,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Cookies
 	 */
-	GetCookies(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): STRING;
+	GetCookies(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): STRING;
 
 	/**
 	 * Get a service definition for this thing
@@ -10140,7 +10140,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as a string
 	 */
-	PutText(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, contentType?: STRING, username?: STRING}): STRING;
+	PutText(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, contentType?: STRING, username?: STRING}): STRING;
 
 	/**
 	 * Get the outgoing dependencies
@@ -10153,7 +10153,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -10182,7 +10182,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as text content
 	 */
-	GetJSON(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): JSON;
+	GetJSON(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): TWJSON;
 
 	/**
 	 * Update/add one or more rows in a multi-row configuration table
@@ -10213,7 +10213,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -10265,7 +10265,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as a JSON Object
 	 */
-	LoadJSON(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): JSON;
+	LoadJSON(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): TWJSON;
 
 	/**
 	 * Has incoming dependencies
@@ -10304,7 +10304,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as text content
 	 */
-	GetText(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, appendHeader?: BOOLEAN, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): STRING;
+	GetText(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, appendHeader?: BOOLEAN, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): STRING;
 
 	/**
 	 * Get the current service definitions for this thing
@@ -10335,7 +10335,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Response as JSON Object
 	 */
-	PostMultipart(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, partsToSend?: INFOTABLE, workstation?: STRING, useProxy?: BOOLEAN, repository?: STRING, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, pathOnRepository?: STRING, domain?: STRING, username?: STRING}): JSON;
+	PostMultipart(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, partsToSend?: INFOTABLE, workstation?: STRING, useProxy?: BOOLEAN, repository?: STRING, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, pathOnRepository?: STRING, domain?: STRING, username?: STRING}): TWJSON;
 
 	/**
 	 * Load JSON content from a URL via HTTP PUT
@@ -10356,7 +10356,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as JSON Object
 	 */
-	PutJSON(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: JSON, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): JSON;
+	PutJSON(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: TWJSON, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): TWJSON;
 
 	/**
 	 * Set home mashup
@@ -10406,7 +10406,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as XML document
 	 */
-	PostXML(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: XML, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): XML;
+	PostXML(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: XML, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): XML;
 
 	/**
 	 * Get home mashup
@@ -10454,7 +10454,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as BLOB Object
 	 */
-	PostBinary(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: BLOB, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): BLOB;
+	PostBinary(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: BLOB, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): BLOB;
 
 	/**
 	 * Set the project name of this entity
@@ -10518,7 +10518,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as JSON Object
 	 */
-	PostJSON(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: JSON, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): JSON;
+	PostJSON(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: TWJSON, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific design time permission for a specific user
@@ -10533,7 +10533,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Load Image content from a URL via HTTP POST
@@ -10554,7 +10554,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as BLOB Object
 	 */
-	PostImage(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, mimeType?: STRING, useProxy?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: IMAGE, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): BLOB;
+	PostImage(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, mimeType?: STRING, useProxy?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: IMAGE, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): BLOB;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -10575,7 +10575,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -10617,7 +10617,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as BLOB Object
 	 */
-	PutBinary(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: BLOB, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): BLOB;
+	PutBinary(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: BLOB, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): BLOB;
 
 	/**
 	 * Delete a design time permission
@@ -10646,7 +10646,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as text content
 	 */
-	GetXML(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): XML;
+	GetXML(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): XML;
 
 	/**
 	 * Get avatar image url
@@ -10681,7 +10681,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as image
 	 */
-	LoadMediaEntity(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, description?: STRING, workstation?: STRING, useProxy?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, tags?: TAGS, proxyPort?: INTEGER, password?: STRING, domain?: STRING, name?: STRING, username?: STRING}): IMAGELINK;
+	LoadMediaEntity(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, description?: STRING, workstation?: STRING, useProxy?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, tags?: TAGS, proxyPort?: INTEGER, password?: STRING, domain?: STRING, name?: STRING, username?: STRING}): IMAGELINK;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -10696,7 +10696,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Load binary content from a URL
@@ -10715,7 +10715,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as an blob/binary primitive
 	 */
-	LoadBinary(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): BLOB;
+	LoadBinary(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): BLOB;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -10744,7 +10744,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as string
 	 */
-	PostText(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, contentType?: STRING, username?: STRING}): STRING;
+	PostText(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, content?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, contentType?: STRING, username?: STRING}): STRING;
 
 	/**
 	 * Get the metadata in InfoTable format
@@ -10804,7 +10804,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as XML document
 	 */
-	LoadXML(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): XML;
+	LoadXML(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, withCookies?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): XML;
 
 	/**
 	 * Append additional tags to an entity
@@ -10830,7 +10830,7 @@ declare class ContentLoaderFunctions extends ResourceEntity {
 	 * @param username Optional user name credential
 	 * @return Loaded content as an image primitive
 	 */
-	LoadImage(args?:{proxyScheme?: STRING, headers?: JSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): IMAGE;
+	LoadImage(args?:{proxyScheme?: STRING, headers?: TWJSON, ignoreSSLErrors?: BOOLEAN, useNTLM?: BOOLEAN, workstation?: STRING, useProxy?: BOOLEAN, proxyHost?: STRING, url?: STRING, timeout?: NUMBER, proxyPort?: INTEGER, password?: STRING, domain?: STRING, username?: STRING}): IMAGE;
 
 	/**
 	 * Get user permissions
@@ -10865,7 +10865,7 @@ declare class MetricServices extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -10910,7 +10910,7 @@ declare class MetricServices extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -10929,7 +10929,7 @@ declare class MetricServices extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -10950,14 +10950,14 @@ declare class MetricServices extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -10969,7 +10969,7 @@ declare class MetricServices extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -11030,7 +11030,7 @@ declare class MetricServices extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -11077,7 +11077,7 @@ declare class MetricServices extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -11276,7 +11276,7 @@ declare class MetricServices extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * sets a Gauge metric to the given value
@@ -11335,7 +11335,7 @@ declare class MetricServices extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -11410,7 +11410,7 @@ declare class MetricServices extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -11515,7 +11515,7 @@ declare class SubsystemMonitoring extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -11560,7 +11560,7 @@ declare class SubsystemMonitoring extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -11579,7 +11579,7 @@ declare class SubsystemMonitoring extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -11600,14 +11600,14 @@ declare class SubsystemMonitoring extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -11619,7 +11619,7 @@ declare class SubsystemMonitoring extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get subsystem status
@@ -11686,7 +11686,7 @@ declare class SubsystemMonitoring extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -11726,7 +11726,7 @@ declare class SubsystemMonitoring extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -11900,7 +11900,7 @@ declare class SubsystemMonitoring extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -11921,7 +11921,7 @@ declare class SubsystemMonitoring extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -11980,7 +11980,7 @@ declare class SubsystemMonitoring extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -12069,7 +12069,7 @@ declare class DataManagementServices extends ResourceEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -12114,7 +12114,7 @@ declare class DataManagementServices extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -12133,7 +12133,7 @@ declare class DataManagementServices extends ResourceEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -12154,14 +12154,14 @@ declare class DataManagementServices extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -12173,7 +12173,7 @@ declare class DataManagementServices extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -12234,7 +12234,7 @@ declare class DataManagementServices extends ResourceEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -12274,7 +12274,7 @@ declare class DataManagementServices extends ResourceEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -12455,7 +12455,7 @@ declare class DataManagementServices extends ResourceEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -12476,7 +12476,7 @@ declare class DataManagementServices extends ResourceEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -12535,7 +12535,7 @@ declare class DataManagementServices extends ResourceEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity

--- a/static/base/Subsystems.d.ts
+++ b/static/base/Subsystems.d.ts
@@ -35,7 +35,7 @@ declare class ValueStreamProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -86,7 +86,7 @@ declare class ValueStreamProcessingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -105,7 +105,7 @@ declare class ValueStreamProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -126,14 +126,14 @@ declare class ValueStreamProcessingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -145,7 +145,7 @@ declare class ValueStreamProcessingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -212,7 +212,7 @@ declare class ValueStreamProcessingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -252,7 +252,7 @@ declare class ValueStreamProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -444,7 +444,7 @@ declare class ValueStreamProcessingSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -465,7 +465,7 @@ declare class ValueStreamProcessingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -524,7 +524,7 @@ declare class ValueStreamProcessingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -641,7 +641,7 @@ declare class WSCommunicationsSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -698,7 +698,7 @@ declare class WSCommunicationsSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -717,7 +717,7 @@ declare class WSCommunicationsSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -738,14 +738,14 @@ declare class WSCommunicationsSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -757,7 +757,7 @@ declare class WSCommunicationsSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -824,7 +824,7 @@ declare class WSCommunicationsSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -864,7 +864,7 @@ declare class WSCommunicationsSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -1063,7 +1063,7 @@ declare class WSCommunicationsSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -1084,7 +1084,7 @@ declare class WSCommunicationsSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -1150,7 +1150,7 @@ declare class WSCommunicationsSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -1266,7 +1266,7 @@ declare class LoggingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -1317,7 +1317,7 @@ declare class LoggingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -1336,7 +1336,7 @@ declare class LoggingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -1357,14 +1357,14 @@ declare class LoggingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -1376,7 +1376,7 @@ declare class LoggingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -1443,7 +1443,7 @@ declare class LoggingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -1483,7 +1483,7 @@ declare class LoggingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -1685,7 +1685,7 @@ declare class LoggingSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Return the configuration table for Logging settings
@@ -1712,7 +1712,7 @@ declare class LoggingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -1771,7 +1771,7 @@ declare class LoggingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -1871,7 +1871,7 @@ declare class ClusteringSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -1922,7 +1922,7 @@ declare class ClusteringSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -1941,7 +1941,7 @@ declare class ClusteringSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -1962,14 +1962,14 @@ declare class ClusteringSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -1981,7 +1981,7 @@ declare class ClusteringSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -2041,7 +2041,7 @@ declare class ClusteringSubsystem extends SubsystemEntity {
 	 * Return status of the cluster.
 	 * @return Cluster Status
 	 */
-	GetClusterStatus(args?:{}): JSON;
+	GetClusterStatus(args?:{}): TWJSON;
 
 	/**
 	 * Get the outgoing dependencies
@@ -2054,7 +2054,7 @@ declare class ClusteringSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -2094,7 +2094,7 @@ declare class ClusteringSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -2292,7 +2292,7 @@ declare class ClusteringSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -2313,7 +2313,7 @@ declare class ClusteringSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -2372,7 +2372,7 @@ declare class ClusteringSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -2478,7 +2478,7 @@ declare class OrderedEventProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -2529,7 +2529,7 @@ declare class OrderedEventProcessingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -2548,7 +2548,7 @@ declare class OrderedEventProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -2569,14 +2569,14 @@ declare class OrderedEventProcessingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -2588,7 +2588,7 @@ declare class OrderedEventProcessingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -2655,7 +2655,7 @@ declare class OrderedEventProcessingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -2695,7 +2695,7 @@ declare class OrderedEventProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -2887,7 +2887,7 @@ declare class OrderedEventProcessingSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -2908,7 +2908,7 @@ declare class OrderedEventProcessingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -2967,7 +2967,7 @@ declare class OrderedEventProcessingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -3067,7 +3067,7 @@ declare class AlertProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -3124,7 +3124,7 @@ declare class AlertProcessingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -3143,7 +3143,7 @@ declare class AlertProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -3164,14 +3164,14 @@ declare class AlertProcessingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -3183,7 +3183,7 @@ declare class AlertProcessingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -3260,7 +3260,7 @@ declare class AlertProcessingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -3300,7 +3300,7 @@ declare class AlertProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -3492,7 +3492,7 @@ declare class AlertProcessingSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -3513,7 +3513,7 @@ declare class AlertProcessingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -3572,7 +3572,7 @@ declare class AlertProcessingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -3672,7 +3672,7 @@ declare class UtilizationSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -3749,7 +3749,7 @@ declare class UtilizationSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -3777,7 +3777,7 @@ declare class UtilizationSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -3810,14 +3810,14 @@ declare class UtilizationSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -3829,7 +3829,7 @@ declare class UtilizationSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -3906,7 +3906,7 @@ declare class UtilizationSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -3946,7 +3946,7 @@ declare class UtilizationSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -4194,7 +4194,7 @@ declare class UtilizationSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Returns the entity statistics
@@ -4248,7 +4248,7 @@ declare class UtilizationSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -4307,7 +4307,7 @@ declare class UtilizationSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -4407,7 +4407,7 @@ declare class ExportImportSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -4458,7 +4458,7 @@ declare class ExportImportSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -4477,7 +4477,7 @@ declare class ExportImportSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -4498,14 +4498,14 @@ declare class ExportImportSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -4517,7 +4517,7 @@ declare class ExportImportSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -4584,7 +4584,7 @@ declare class ExportImportSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -4624,7 +4624,7 @@ declare class ExportImportSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -4816,7 +4816,7 @@ declare class ExportImportSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -4837,7 +4837,7 @@ declare class ExportImportSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -4896,7 +4896,7 @@ declare class ExportImportSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -4996,7 +4996,7 @@ declare class IntegrationSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -5047,7 +5047,7 @@ declare class IntegrationSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -5066,7 +5066,7 @@ declare class IntegrationSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -5087,14 +5087,14 @@ declare class IntegrationSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -5106,7 +5106,7 @@ declare class IntegrationSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -5179,7 +5179,7 @@ declare class IntegrationSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -5219,7 +5219,7 @@ declare class IntegrationSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -5234,7 +5234,7 @@ declare class IntegrationSubsystem extends SubsystemEntity {
 	 * @param MappingIds The mapping rule Ids
 	 * @return result
 	 */
-	DeleteMappings(args?:{MappingIds?: JSON}): NOTHING;
+	DeleteMappings(args?:{MappingIds?: TWJSON}): NOTHING;
 
 	/**
 	 * Add a run time permission
@@ -5259,7 +5259,7 @@ declare class IntegrationSubsystem extends SubsystemEntity {
 	 * @param MappingId The mapping rule Id
 	 * @return 
 	 */
-	GetMapping(args?:{MappingId?: STRING}): JSON;
+	GetMapping(args?:{MappingId?: STRING}): TWJSON;
 
 	/**
 	 * Get the description for an entity
@@ -5328,7 +5328,7 @@ declare class IntegrationSubsystem extends SubsystemEntity {
 	 * @param ConnectorName The connector on which this apiMap was generated.
 	 * @return result
 	 */
-	StoreMapping(args?:{MappingId?: STRING, ApiName?: JSON, MappingJSON?: JSON, ConnectorName?: STRING}): NOTHING;
+	StoreMapping(args?:{MappingId?: STRING, ApiName?: TWJSON, MappingJSON?: TWJSON, ConnectorName?: STRING}): NOTHING;
 
 	/**
 	 * Assign an owner to this entity
@@ -5454,7 +5454,7 @@ declare class IntegrationSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -5475,7 +5475,7 @@ declare class IntegrationSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -5534,7 +5534,7 @@ declare class IntegrationSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -5634,7 +5634,7 @@ declare class EventProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -5685,7 +5685,7 @@ declare class EventProcessingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -5704,7 +5704,7 @@ declare class EventProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -5725,14 +5725,14 @@ declare class EventProcessingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -5744,7 +5744,7 @@ declare class EventProcessingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -5811,7 +5811,7 @@ declare class EventProcessingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -5851,7 +5851,7 @@ declare class EventProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -6049,7 +6049,7 @@ declare class EventProcessingSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -6070,7 +6070,7 @@ declare class EventProcessingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -6129,7 +6129,7 @@ declare class EventProcessingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -6229,7 +6229,7 @@ declare class StreamProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -6280,7 +6280,7 @@ declare class StreamProcessingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -6299,7 +6299,7 @@ declare class StreamProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -6320,14 +6320,14 @@ declare class StreamProcessingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -6339,7 +6339,7 @@ declare class StreamProcessingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -6406,7 +6406,7 @@ declare class StreamProcessingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -6446,7 +6446,7 @@ declare class StreamProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -6638,7 +6638,7 @@ declare class StreamProcessingSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -6659,7 +6659,7 @@ declare class StreamProcessingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -6718,7 +6718,7 @@ declare class StreamProcessingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -6831,7 +6831,7 @@ declare class FileTransferSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -6882,7 +6882,7 @@ declare class FileTransferSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -6901,7 +6901,7 @@ declare class FileTransferSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -6922,14 +6922,14 @@ declare class FileTransferSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -6941,7 +6941,7 @@ declare class FileTransferSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get queued transfer job for transfer job id
@@ -7022,7 +7022,7 @@ declare class FileTransferSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -7070,7 +7070,7 @@ declare class FileTransferSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -7118,7 +7118,7 @@ declare class FileTransferSubsystem extends SubsystemEntity {
 	 * @param timeout How many seconds to wait for a result
 	 * @return Transfer information
 	 */
-	Copy(args?:{async?: BOOLEAN, sourceRepo?: STRING, metadata?: JSON, targetRepo?: STRING, targetFile?: STRING, targetPath?: STRING, queueable?: BOOLEAN, sourceFile?: STRING, sourcePath?: STRING, timeout?: INTEGER}): INFOTABLE<FileTransferJob>;
+	Copy(args?:{async?: BOOLEAN, sourceRepo?: STRING, metadata?: TWJSON, targetRepo?: STRING, targetFile?: STRING, targetPath?: STRING, queueable?: BOOLEAN, sourceFile?: STRING, sourcePath?: STRING, timeout?: INTEGER}): INFOTABLE<FileTransferJob>;
 
 	/**
 	 * Is the file transfer job active?
@@ -7314,7 +7314,7 @@ declare class FileTransferSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get a list of transfer jobs that are active
@@ -7347,7 +7347,7 @@ declare class FileTransferSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -7413,7 +7413,7 @@ declare class FileTransferSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get queued transfer job count by Thing name
@@ -7539,7 +7539,7 @@ declare class UserManagementSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -7590,7 +7590,7 @@ declare class UserManagementSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Returns whether concurrent user sessions are restricted
@@ -7621,7 +7621,7 @@ declare class UserManagementSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Sets if unauthenticated users should get redirect to Form Login instead of Basic Auth challenge
@@ -7649,14 +7649,14 @@ declare class UserManagementSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -7668,7 +7668,7 @@ declare class UserManagementSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -7741,7 +7741,7 @@ declare class UserManagementSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Sets how permissions are evaluated when services are executed on User entities
@@ -7788,7 +7788,7 @@ declare class UserManagementSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -8005,7 +8005,7 @@ declare class UserManagementSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -8026,7 +8026,7 @@ declare class UserManagementSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -8106,7 +8106,7 @@ declare class UserManagementSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -8213,7 +8213,7 @@ declare class TunnelSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -8264,7 +8264,7 @@ declare class TunnelSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -8283,7 +8283,7 @@ declare class TunnelSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -8304,14 +8304,14 @@ declare class TunnelSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -8323,7 +8323,7 @@ declare class TunnelSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -8396,7 +8396,7 @@ declare class TunnelSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Start a tunnel
@@ -8445,7 +8445,7 @@ declare class TunnelSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -8645,7 +8645,7 @@ declare class TunnelSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get a list of active tunnels
@@ -8673,7 +8673,7 @@ declare class TunnelSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -8732,7 +8732,7 @@ declare class TunnelSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -8832,7 +8832,7 @@ declare class MessageStoreSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -8898,7 +8898,7 @@ declare class MessageStoreSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -8917,7 +8917,7 @@ declare class MessageStoreSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -8938,14 +8938,14 @@ declare class MessageStoreSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -8957,7 +8957,7 @@ declare class MessageStoreSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -9038,7 +9038,7 @@ declare class MessageStoreSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -9084,7 +9084,7 @@ declare class MessageStoreSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -9317,7 +9317,7 @@ declare class MessageStoreSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -9338,7 +9338,7 @@ declare class MessageStoreSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -9397,7 +9397,7 @@ declare class MessageStoreSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -9476,7 +9476,7 @@ declare class LicensingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -9519,13 +9519,13 @@ declare class LicensingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * User group usage Info
@@ -9591,7 +9591,7 @@ declare class LicensingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Acquire License from License Server
@@ -9684,7 +9684,7 @@ declare class LicensingSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -9780,7 +9780,7 @@ declare class LicensingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -9799,7 +9799,7 @@ declare class LicensingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get the incoming dependencies as a network
@@ -9814,7 +9814,7 @@ declare class LicensingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -9863,7 +9863,7 @@ declare class LicensingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -10064,7 +10064,7 @@ declare class LicensingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -10107,7 +10107,7 @@ declare class LicensingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -10196,7 +10196,7 @@ declare class FederationSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -10255,7 +10255,7 @@ declare class FederationSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -10274,7 +10274,7 @@ declare class FederationSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -10295,14 +10295,14 @@ declare class FederationSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -10314,7 +10314,7 @@ declare class FederationSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -10381,7 +10381,7 @@ declare class FederationSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -10428,7 +10428,7 @@ declare class FederationSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -10632,7 +10632,7 @@ declare class FederationSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -10653,7 +10653,7 @@ declare class FederationSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -10719,7 +10719,7 @@ declare class FederationSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -10828,7 +10828,7 @@ declare class DataTableProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -10879,7 +10879,7 @@ declare class DataTableProcessingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -10898,7 +10898,7 @@ declare class DataTableProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -10919,14 +10919,14 @@ declare class DataTableProcessingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -10938,7 +10938,7 @@ declare class DataTableProcessingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -11005,7 +11005,7 @@ declare class DataTableProcessingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -11045,7 +11045,7 @@ declare class DataTableProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -11237,7 +11237,7 @@ declare class DataTableProcessingSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -11258,7 +11258,7 @@ declare class DataTableProcessingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -11317,7 +11317,7 @@ declare class DataTableProcessingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -11396,7 +11396,7 @@ declare class PlatformSubsystem extends SubsystemEntity {
 	 * Return the configuration settings for enabling/disabling mashup features
 	 * @return JSON object with mashup configuration values
 	 */
-	GetMashupConfiguration(args?:{}): JSON;
+	GetMashupConfiguration(args?:{}): TWJSON;
 
 	/**
 	 * Stops the sub-system
@@ -11408,7 +11408,7 @@ declare class PlatformSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -11457,13 +11457,13 @@ declare class PlatformSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get information on how the subsystem is performing
@@ -11521,13 +11521,13 @@ declare class PlatformSubsystem extends SubsystemEntity {
 	 * @param minimalSerialization Indicates if content should be minimized for mashup runtime
 	 * @return List of style themes
 	 */
-	GetAllStyleThemes(args?:{minimalSerialization?: BOOLEAN}): JSON;
+	GetAllStyleThemes(args?:{minimalSerialization?: BOOLEAN}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Returns the default property persistence provider name
@@ -11639,13 +11639,13 @@ declare class PlatformSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Return the learning connector configuration
 	 * @return Properties of the Learning Connector configuration
 	 */
-	GetLearningConnectorConfiguration(args?:{}): JSON;
+	GetLearningConnectorConfiguration(args?:{}): TWJSON;
 
 	/**
 	 * Deletes the specified ExtensionPackage and all associated Extensions if not in use
@@ -11799,7 +11799,7 @@ declare class PlatformSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Return a list of Extensions associated with the specified ExtensionPackage
@@ -11825,7 +11825,7 @@ declare class PlatformSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get the incoming dependencies as a network
@@ -11840,14 +11840,14 @@ declare class PlatformSubsystem extends SubsystemEntity {
 	 * @param minimalSerialization Indicates if content should be minimized for mashup runtime
 	 * @return List of style definitions
 	 */
-	GetAllStyleDefinitions(args?:{minimalSerialization?: BOOLEAN}): JSON;
+	GetAllStyleDefinitions(args?:{minimalSerialization?: BOOLEAN}): TWJSON;
 
 	/**
 	 * Set a list of assigned runtime permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -11891,13 +11891,13 @@ declare class PlatformSubsystem extends SubsystemEntity {
 	 * @param minimalSerialization Indicates if content should be minimized for mashup runtime
 	 * @return List of state definitions
 	 */
-	GetAllStateDefinitions(args?:{minimalSerialization?: BOOLEAN}): JSON;
+	GetAllStateDefinitions(args?:{minimalSerialization?: BOOLEAN}): TWJSON;
 
 	/**
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -12143,7 +12143,7 @@ declare class PlatformSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -12180,7 +12180,7 @@ declare class PlatformSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -12275,7 +12275,7 @@ declare class AuditSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -12338,7 +12338,7 @@ declare class AuditSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -12357,7 +12357,7 @@ declare class AuditSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -12378,14 +12378,14 @@ declare class AuditSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -12397,7 +12397,7 @@ declare class AuditSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -12464,7 +12464,7 @@ declare class AuditSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -12504,7 +12504,7 @@ declare class AuditSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -12715,7 +12715,7 @@ declare class AuditSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -12736,7 +12736,7 @@ declare class AuditSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -12801,7 +12801,7 @@ declare class AuditSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -12901,7 +12901,7 @@ declare class WSExecutionProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -12952,7 +12952,7 @@ declare class WSExecutionProcessingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -12971,7 +12971,7 @@ declare class WSExecutionProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -12992,14 +12992,14 @@ declare class WSExecutionProcessingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -13011,7 +13011,7 @@ declare class WSExecutionProcessingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -13078,7 +13078,7 @@ declare class WSExecutionProcessingSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -13118,7 +13118,7 @@ declare class WSExecutionProcessingSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -13310,7 +13310,7 @@ declare class WSExecutionProcessingSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -13331,7 +13331,7 @@ declare class WSExecutionProcessingSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -13390,7 +13390,7 @@ declare class WSExecutionProcessingSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -13490,7 +13490,7 @@ declare class SCIMSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -13553,7 +13553,7 @@ declare class SCIMSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Set the User Provisioning Defaults
@@ -13579,7 +13579,7 @@ declare class SCIMSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -13600,14 +13600,14 @@ declare class SCIMSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -13619,7 +13619,7 @@ declare class SCIMSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -13686,7 +13686,7 @@ declare class SCIMSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -13733,7 +13733,7 @@ declare class SCIMSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -13957,7 +13957,7 @@ declare class SCIMSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Return the Group Provisioning Group Default Settings
@@ -13991,7 +13991,7 @@ declare class SCIMSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -14057,7 +14057,7 @@ declare class SCIMSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -14157,7 +14157,7 @@ declare class WorkflowSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -14208,7 +14208,7 @@ declare class WorkflowSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -14227,7 +14227,7 @@ declare class WorkflowSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -14248,14 +14248,14 @@ declare class WorkflowSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -14267,7 +14267,7 @@ declare class WorkflowSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -14334,7 +14334,7 @@ declare class WorkflowSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -14374,7 +14374,7 @@ declare class WorkflowSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -14566,7 +14566,7 @@ declare class WorkflowSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the current property definitions for this thing
@@ -14587,7 +14587,7 @@ declare class WorkflowSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -14646,7 +14646,7 @@ declare class WorkflowSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity
@@ -14746,7 +14746,7 @@ declare class SolutionCentralSubsystem extends SubsystemEntity {
 	 * Get a list of assigned designtime permissions
 	 * @return Permission list
 	 */
-	GetDesignTimePermissionsAsJSON(args?:{}): JSON;
+	GetDesignTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for a specific group
@@ -14809,7 +14809,7 @@ declare class SolutionCentralSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetInstanceMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Remove tags from an entity
@@ -14828,7 +14828,7 @@ declare class SolutionCentralSubsystem extends SubsystemEntity {
 	 * Get a list of assigned visibility permissions
 	 * @return Permission list
 	 */
-	GetVisibilityPermissionsAsJSON(args?:{}): JSON;
+	GetVisibilityPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a list of assigned runtime permissions
@@ -14849,14 +14849,14 @@ declare class SolutionCentralSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetRunTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetRunTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Set a list of assigned visibility permissions
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetVisibilityPermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetVisibilityPermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -14868,7 +14868,7 @@ declare class SolutionCentralSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataAsJSON(args?:{}): JSON;
+	GetMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Get a service definition for this thing
@@ -14935,7 +14935,7 @@ declare class SolutionCentralSubsystem extends SubsystemEntity {
 	 * Get the instance metadata in JSON format
 	 * @return Instance metadata
 	 */
-	GetInstanceMetadataAsJSON(args?:{}): JSON;
+	GetInstanceMetadataAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Delete one or more rows from a multi-row configuration table
@@ -14975,7 +14975,7 @@ declare class SolutionCentralSubsystem extends SubsystemEntity {
 	 * Get a list of assigned runtime permissions
 	 * @return Permission list
 	 */
-	GetRunTimePermissionsAsJSON(args?:{}): JSON;
+	GetRunTimePermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Check to see if an entity has a specific run time permission for the current user
@@ -15181,7 +15181,7 @@ declare class SolutionCentralSubsystem extends SubsystemEntity {
 	 * @param otherEntity Entity to compare
 	 * @return Created Infotable
 	 */
-	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): JSON;
+	GetDifferencesAsJSON(args?:{otherEntity?: STRING}): TWJSON;
 
 	/**
 	 * Get the expiration date of certificate used to communicate with Solution Central
@@ -15208,7 +15208,7 @@ declare class SolutionCentralSubsystem extends SubsystemEntity {
 	 * @param permissions Permissions in JSON format
 	 * @return result
 	 */
-	SetDesignTimePermissionsAsJSON(args?:{permissions?: JSON}): NOTHING;
+	SetDesignTimePermissionsAsJSON(args?:{permissions?: TWJSON}): NOTHING;
 
 	/**
 	 * Has outgoing dependencies
@@ -15267,7 +15267,7 @@ declare class SolutionCentralSubsystem extends SubsystemEntity {
 	 * Get the metadata in JSON format
 	 * @return  metadata
 	 */
-	GetMetadataWithPermissionsAsJSON(args?:{}): JSON;
+	GetMetadataWithPermissionsAsJSON(args?:{}): TWJSON;
 
 	/**
 	 * Overwrite/set the tags for an entity

--- a/static/base/ThingShapes.d.ts
+++ b/static/base/ThingShapes.d.ts
@@ -657,7 +657,7 @@ declare class RemoteMetadataBrowsing extends ThingShapeBase {
 	 * Get the metadata for a thing
 	 * @return The thing's metadata
 	 */
-	GetRemoteMetadata(args?:{}): JSON;
+	GetRemoteMetadata(args?:{}): TWJSON;
 
 
 }


### PR DESCRIPTION
Fixes #40 

Replaces all instances of the `JSON` type with the `TWJSON` type in the default entity files.

Improves the formatting of the upload response message. Instead of printing out the JSON response that Thingworx provides, the build script will now try to extract and present the relevant information.