### PR TITLE
Bump thing cli version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^8.10.11",
-				"bm-thing-cli": "^1.0.1"
+				"bm-thing-cli": "^1.0.2"
 			}
 		},
 		"../ThingCLI": {
@@ -59,9 +59,9 @@
 			}
 		},
 		"node_modules/bm-thing-cli": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/bm-thing-cli/-/bm-thing-cli-1.0.1.tgz",
-			"integrity": "sha512-0DMauv2RiFlxWbVXwFedoUI8YaWGlEGIGdWfTQEcNRUGcdL78jCYxlyyRjmYq9DKOqCCFlf8h0iRcvOTZKwzpA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bm-thing-cli/-/bm-thing-cli-1.0.2.tgz",
+			"integrity": "sha512-zwieQZMS9c6ndvtAhMsEojVvoMJKUnajfsuekhaQetRIsGJGOUU3iiav48JYpWP1csSA+oQziQsQvKyVRw4AGg==",
 			"dev": true,
 			"dependencies": {
 				"adm-zip": "0.5.9",
@@ -168,9 +168,9 @@
 			"dev": true
 		},
 		"bm-thing-cli": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/bm-thing-cli/-/bm-thing-cli-1.0.1.tgz",
-			"integrity": "sha512-0DMauv2RiFlxWbVXwFedoUI8YaWGlEGIGdWfTQEcNRUGcdL78jCYxlyyRjmYq9DKOqCCFlf8h0iRcvOTZKwzpA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bm-thing-cli/-/bm-thing-cli-1.0.2.tgz",
+			"integrity": "sha512-zwieQZMS9c6ndvtAhMsEojVvoMJKUnajfsuekhaQetRIsGJGOUU3iiav48JYpWP1csSA+oQziQsQvKyVRw4AGg==",
 			"dev": true,
 			"requires": {
 				"adm-zip": "0.5.9",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
 	],
 	"devDependencies": {
 		"@types/node": "^8.10.11",
-		"bm-thing-cli": "^1.0.1"
+		"bm-thing-cli": "^1.0.2"
 	}
 }


### PR DESCRIPTION
Resolves an issue where using the `add-project` command would cause an incorrect `tsconfig.json` file to be generated for the new project. The configuration had the incorrect path to the collection declaration files, preventing the subprojects from accessing their own entities via collections.