### PR TITLE
Fix inlining enum members in global functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 13 Apr 2024
+
+Fixes a bug where enum members were not properly inlined when referenced by global functions defined on the first line of a file.
+
+Update the typings for the `DisableSubscription` and `EnableSubscription` to support the new signatures in Thingworx 9. ([kklorenzotesta](https://github.com/kklorenzotesta))
+
 # 6 Apr 2024
 
 Resolves an issue where certain global functions were not properly copied over into services.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ For a complete changelog see [CHANGELOG.md](CHANGELOG.md).
 
 [CozminM](https://github.com/CozminM), [elena-bi](https://github.com/elena-bi) - bug fixes
 
+[kklorenzotesta](https://github.com/kklorenzotesta) - thingworx API typing updates
+
 # Disclaimer
 
 The Thingworx VSCode Project is not an official Thingworx product. It is something developed to improve the life of a Thingworx developer and they need to understand that it is not supported and any issues encountered are their own responsibility.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "bm-thingworx-vscode",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "bm-thingworx-vscode",
-			"version": "3.0.1",
+			"version": "3.0.2",
 			"license": "MIT",
 			"devDependencies": {
-				"bm-thing-cli": "2.0.1"
+				"bm-thing-cli": "^2.0.2"
 			}
 		},
 		"../ThingCLI": {
@@ -52,13 +52,13 @@
 			}
 		},
 		"node_modules/bm-thing-cli": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/bm-thing-cli/-/bm-thing-cli-2.0.1.tgz",
-			"integrity": "sha512-Urmm0U7KI2rMSTlhnxFWJf3FgMIh+H59zU35P1TrTTtVW/qODUrQfcyo5kgpS7sWGqIfyrcSzHHefk65rL3Lqg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bm-thing-cli/-/bm-thing-cli-2.0.2.tgz",
+			"integrity": "sha512-XfI40Q1bHRhIzY/+ZYeiIfqqGisjdr97yIZYjaHBwnmtvBBwEw/c2FDVS9xcRkXPvkkwFTm200arnm6AkdCgZA==",
 			"dev": true,
 			"dependencies": {
 				"adm-zip": "0.5.10",
-				"bm-thing-transformer": "2.0.1",
+				"bm-thing-transformer": "2.0.2",
 				"dotenv": "^16.0.0",
 				"enquirer": "^2.3.6",
 				"typescript": "4.6.3",
@@ -72,9 +72,9 @@
 			}
 		},
 		"node_modules/bm-thing-transformer": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-2.0.1.tgz",
-			"integrity": "sha512-6QNyOis/VIDq9zdHhEU3+ZfaSXRHxCw3NSOuyuoNLSzr3ozLZQO2uUxvLTdwYr5+kix0aY677OaoSfpkpNVKmQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-2.0.2.tgz",
+			"integrity": "sha512-kK7tDLJjrqu9rFhRK2OE0VVJ0uzNiROtdvZ7Z8SSmKoKwLVvVJjT/FrhSlglqIrx4Q7DT0sQ8CGF6E5TDpAZSw==",
 			"dev": true,
 			"dependencies": {
 				"typescript": "4.6.3",
@@ -165,13 +165,13 @@
 			"dev": true
 		},
 		"bm-thing-cli": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/bm-thing-cli/-/bm-thing-cli-2.0.1.tgz",
-			"integrity": "sha512-Urmm0U7KI2rMSTlhnxFWJf3FgMIh+H59zU35P1TrTTtVW/qODUrQfcyo5kgpS7sWGqIfyrcSzHHefk65rL3Lqg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bm-thing-cli/-/bm-thing-cli-2.0.2.tgz",
+			"integrity": "sha512-XfI40Q1bHRhIzY/+ZYeiIfqqGisjdr97yIZYjaHBwnmtvBBwEw/c2FDVS9xcRkXPvkkwFTm200arnm6AkdCgZA==",
 			"dev": true,
 			"requires": {
 				"adm-zip": "0.5.10",
-				"bm-thing-transformer": "2.0.1",
+				"bm-thing-transformer": "2.0.2",
 				"dotenv": "^16.0.0",
 				"enquirer": "^2.3.6",
 				"typescript": "4.6.3",
@@ -179,9 +179,9 @@
 			}
 		},
 		"bm-thing-transformer": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-2.0.1.tgz",
-			"integrity": "sha512-6QNyOis/VIDq9zdHhEU3+ZfaSXRHxCw3NSOuyuoNLSzr3ozLZQO2uUxvLTdwYr5+kix0aY677OaoSfpkpNVKmQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-2.0.2.tgz",
+			"integrity": "sha512-kK7tDLJjrqu9rFhRK2OE0VVJ0uzNiROtdvZ7Z8SSmKoKwLVvVJjT/FrhSlglqIrx4Q7DT0sQ8CGF6E5TDpAZSw==",
 			"dev": true,
 			"requires": {
 				"typescript": "4.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bm-thingworx-vscode",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"description": "Develop in ThingWorx with a proper IDE.",
 	"author": "Thingworx RoIcenter",
 	"thingworxProjectName": "MyProject",
@@ -32,6 +32,6 @@
 		"LICENSE"
 	],
 	"devDependencies": {
-		"bm-thing-cli": "2.0.1"
+		"bm-thing-cli": "^2.0.2"
 	}
 }


### PR DESCRIPTION
Fixes a bug where enum members were not properly inlined when referenced by global functions defined on the first line of a file.

Update the typings for the `DisableSubscription` and `EnableSubscription` to support the new signatures in Thingworx 9. ([kklorenzotesta](https://github.com/kklorenzotesta))