### PR TITLE
3.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 25 May 2024
+
+Adds support for specifying visibility permissions on mashups. ([kklorenzotesta](https://github.com/kklorenzotesta))
+
+Resolves an issue where using `this` in an arrow function produced incorrect code. ([kklorenzotesta](https://github.com/kklorenzotesta))
+
 # 20 Apr 2024
 
 Updates the Typescript version to 5.4. ([stefan-lacatus](https://github.com/stefan-lacatus))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "bm-thingworx-vscode",
-	"version": "3.1.0",
+	"version": "3.1.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "bm-thingworx-vscode",
-			"version": "3.1.0",
+			"version": "3.1.5",
 			"license": "MIT",
 			"devDependencies": {
-				"bm-thing-cli": "^2.1.0"
+				"bm-thing-cli": "^2.1.5"
 			}
 		},
 		"../ThingCLI": {
@@ -52,13 +52,13 @@
 			}
 		},
 		"node_modules/bm-thing-cli": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/bm-thing-cli/-/bm-thing-cli-2.1.0.tgz",
-			"integrity": "sha512-1WcDKXhWLIsjqkHaLHJWCkDDLlIgILo10yhmY/nA3s85vlVzUzemTJ00F57i087S9sQKsMOpMJnHAcUqcJnrrg==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/bm-thing-cli/-/bm-thing-cli-2.1.5.tgz",
+			"integrity": "sha512-ydHJYrspAGvW+OVPXEb/duVFyKNsHVhwHmRB356YaPrY89YZu0W+478hWLHLeXAkllyJEeNKt+Yh+um3Y2iO3g==",
 			"dev": true,
 			"dependencies": {
 				"adm-zip": "0.5.10",
-				"bm-thing-transformer": "2.1.0",
+				"bm-thing-transformer": "2.1.5",
 				"dotenv": "^16.0.0",
 				"enquirer": "^2.3.6",
 				"typescript": "5.4.5",
@@ -72,9 +72,9 @@
 			}
 		},
 		"node_modules/bm-thing-transformer": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-2.1.0.tgz",
-			"integrity": "sha512-bA4vnITepPVXX4i4xZR0zCQvil0E13qQpEp8N3jWkMCdIS58SoPoQeZIo+RXPEvEFmWrZyaKQd8b8SF1Gy0bBw==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-2.1.5.tgz",
+			"integrity": "sha512-5gYci8b7hmVLqgDfnymwHgTn3mVxBNllflzgANCUw6EX/smkGTH7F63qBPYgswcrCr6HOBYCWU+2P1dSNP03ig==",
 			"dev": true,
 			"dependencies": {
 				"typescript": "5.4.5",
@@ -165,13 +165,13 @@
 			"dev": true
 		},
 		"bm-thing-cli": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/bm-thing-cli/-/bm-thing-cli-2.1.0.tgz",
-			"integrity": "sha512-1WcDKXhWLIsjqkHaLHJWCkDDLlIgILo10yhmY/nA3s85vlVzUzemTJ00F57i087S9sQKsMOpMJnHAcUqcJnrrg==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/bm-thing-cli/-/bm-thing-cli-2.1.5.tgz",
+			"integrity": "sha512-ydHJYrspAGvW+OVPXEb/duVFyKNsHVhwHmRB356YaPrY89YZu0W+478hWLHLeXAkllyJEeNKt+Yh+um3Y2iO3g==",
 			"dev": true,
 			"requires": {
 				"adm-zip": "0.5.10",
-				"bm-thing-transformer": "2.1.0",
+				"bm-thing-transformer": "2.1.5",
 				"dotenv": "^16.0.0",
 				"enquirer": "^2.3.6",
 				"typescript": "5.4.5",
@@ -179,9 +179,9 @@
 			}
 		},
 		"bm-thing-transformer": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-2.1.0.tgz",
-			"integrity": "sha512-bA4vnITepPVXX4i4xZR0zCQvil0E13qQpEp8N3jWkMCdIS58SoPoQeZIo+RXPEvEFmWrZyaKQd8b8SF1Gy0bBw==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-2.1.5.tgz",
+			"integrity": "sha512-5gYci8b7hmVLqgDfnymwHgTn3mVxBNllflzgANCUw6EX/smkGTH7F63qBPYgswcrCr6HOBYCWU+2P1dSNP03ig==",
 			"dev": true,
 			"requires": {
 				"typescript": "5.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bm-thingworx-vscode",
-	"version": "3.1.0",
+	"version": "3.1.5",
 	"description": "Develop in ThingWorx with a proper IDE.",
 	"author": "Thingworx RoIcenter",
 	"thingworxProjectName": "MyProject",
@@ -32,6 +32,6 @@
 		"LICENSE"
 	],
 	"devDependencies": {
-		"bm-thing-cli": "^2.1.0"
+		"bm-thing-cli": "^2.1.5"
 	}
 }


### PR DESCRIPTION
Adds support for specifying visibility permissions on mashups. ([kklorenzotesta](https://github.com/kklorenzotesta))

Resolves an issue where using `this` in an arrow function produced incorrect code. ([kklorenzotesta](https://github.com/kklorenzotesta))